### PR TITLE
Deploy client to GitHub pages

### DIFF
--- a/.github/workflows/deploy-client.yml
+++ b/.github/workflows/deploy-client.yml
@@ -1,0 +1,61 @@
+name: Deploy Web Client to Pages
+
+on:
+  push:
+    branches: [main]
+    paths: ['web-client/**', '.github/workflows/deploy-client.yml']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web-client
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+          cache-dependency-path: web-client/package-lock.json
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Build the production bundle
+        env:
+          VITE_API_BASE: ${{ vars.VITE_API_BASE }}
+        run: npm run build
+
+        # GitHub is a static file server, but we only have one index.html.
+        # Therefore, we copy this index.html to GitHub's 404 page, and React will decide what to render.
+      - name: Copy index.html to 404.html
+        run: cp dist/index.html dist/404.html
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload built site as Pages artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: web-client/dist
+
+      - name: Publish to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/web-client/src/App.tsx
+++ b/web-client/src/App.tsx
@@ -4,7 +4,7 @@ import { NotFoundPage } from './pages/NotFoundPage'
 
 export default function App() {
   return (
-    <BrowserRouter>
+    <BrowserRouter basename={import.meta.env.BASE_URL}>
       <Routes>
         <Route path="/" element={<Navigate to="/generate" replace />} />
         <Route path="/generate" element={<GeneratePage />} />

--- a/web-client/vite.config.ts
+++ b/web-client/vite.config.ts
@@ -3,5 +3,6 @@ import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 
 export default defineConfig({
+  base: '/team-devsecops/',
   plugins: [react(), tailwindcss()],
 })


### PR DESCRIPTION
Left to do to make this work @imol-ai:

- [ ] after deploying the Spring API: Repo Settings → Secrets and variables → Actions → Variables tab → New repository variable: set VITE_API_BASE to the URL of the Spring API on GCP
- [ ] add CORS to the Spring API:
```java
@Configuration
class CorsConfig : WebMvcConfigurer {
	override fun addCorsMappings(registry: CorsRegistry) {
		registry.addMapping("/api/**")
			.allowedOrigins("https://aet-devops26.github.io")
			.allowedMethods("POST")
	}
}
```