### PR TITLE
docs: add live app URL and local setup to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
 # team-devsecops
-Repository for team DevSecOps
+
+Repository for team DevSecOps.
+
+## Deployment
+
+> **Live app:** https://aet-devops26.github.io/team-devsecops
+
+## Local setup
+
+```bash
+# Web client
+cd web-client && npm install && npm run dev
+
+# Spring API
+cd services/spring-api && ./gradlew bootRun
+
+# Python services
+cd services/py-help-service && pip install -r requirements.txt && python main.py
+cd services/py-recipe-service && pip install -r requirements.txt && python main.py
+```

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # team-devsecops
 
-Repository for team DevSecOps.
+Repository for team DevSecOps — a GenAI-powered cooking assistant that recommends recipes based on user preferences.
 
 ## Deployment
 
 > **Live app:** https://aet-devops26.github.io/team-devsecops
+
+See the [project wiki](https://github.com/AET-DevOps26/team-devsecops/wiki) for the [problem statement](https://github.com/AET-DevOps26/team-devsecops/wiki/Problem-Statement) and [initial system structure](https://github.com/AET-DevOps26/team-devsecops/wiki/Initial-System-Structure).
 
 ## Local setup
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-# team-devsecops
-
-Repository for team DevSecOps — a GenAI-powered cooking assistant that recommends recipes based on user preferences.
+# Cooking Assistant (Team DevSecOps)
 
 ## Deployment
 


### PR DESCRIPTION
## Summary
- Adds the live app URL (https://aet-devops26.github.io/team-devsecops) prominently to the README
- Adds brief local setup commands for the web client, Spring API, and both Python services

## Test plan
- [ ] Verify the live app link resolves
- [ ] Skim the rendered README on GitHub for formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)