### PR TITLE
fix(web-client): strip Origin in dev proxy so Spring skips CORS

### DIFF
--- a/web-client/vite.config.ts
+++ b/web-client/vite.config.ts
@@ -8,7 +8,16 @@ export default defineConfig({
   server: {
 		// mappings when running in dev mode
     proxy: {
-      '/api': 'http://localhost:8080',
+      '/api': {
+        target: 'http://localhost:8080',
+        configure: (proxy) => {
+          proxy.on('proxyReq', (proxyReq) => {
+            // Spring's CorsConfig only allows the GitHub Pages origin; strip
+            // the browser's Origin so Spring skips CORS in local dev.
+            proxyReq.removeHeader('origin')
+          })
+        },
+      },
     },
   },
 })


### PR DESCRIPTION
Strip the `Origin` header when running locally to avoid issues with CORS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)