### PR TITLE
ci: restrict PR preview deploy to web-client changes

### DIFF
--- a/.github/workflows/deploy-client-previews.yml
+++ b/.github/workflows/deploy-client-previews.yml
@@ -2,6 +2,7 @@ name: Deploy PR Preview to Cloudflare Pages
 on:
     pull_request:
         types: [ opened, synchronize, reopened, closed ]
+        paths: [ 'web-client/**' ]
 
 jobs:
     deploy:


### PR DESCRIPTION
## Summary

Adds a `paths` filter to the Cloudflare Pages preview workflow so it only triggers on PRs that touch `web-client/`.

## Why

Previously `deploy-client-previews.yml` ran on every PR regardless of which files changed, spinning up preview deployments for backend-only changes that have no client to preview.

## Notes

- The `cleanup` job (on `closed`) still fires for any PR that ever changed `web-client/`. PRs that never touched it never run `deploy`, so there's nothing to clean up — consistent behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)