### PR TITLE
fix(cors): allow 127.0.0.1 and 0.0.0.0 local origins

### DIFF
--- a/services/spring-api/src/main/kotlin/org/openapitools/config/CorsConfig.kt
+++ b/services/spring-api/src/main/kotlin/org/openapitools/config/CorsConfig.kt
@@ -10,7 +10,9 @@ class CorsConfig : WebMvcConfigurer {
 		registry.addMapping("/api/**")
 			.allowedOriginPatterns(
 				"https://aet-devops26.github.io",
-        "http://localhost:8080",
+				"http://localhost:8080",
+				"http://127.0.0.1:8080",
+				"http://0.0.0.0:8080",
 				"https://*.team-devsecops.pages.dev",
 			)
 			.allowedMethods("POST")


### PR DESCRIPTION
## Problem

Spring's CORS filter (`CorsConfig.kt`) only allowed `http://localhost:8080` as a local origin. Opening the app via `http://127.0.0.1:8080` or `http://0.0.0.0:8080` — both normal ways to reach a local Docker stack — produced `403 Invalid CORS request` on every API submit, before the controller ever ran.

## Change

Add `http://127.0.0.1:8080` and `http://0.0.0.0:8080` to `allowedOriginPatterns`. Also normalised the indentation of the existing `localhost` line (was spaces, now tabs like its siblings).

## Note

This requires a rebuilt image to take effect — `docker compose up` reuses cached images. Use `docker compose up --build` (or `docker compose watch`) after pulling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)