### PR TITLE
Set up database, userauth & profiles, and recipe gen service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,9 @@
 # Copy to .env and fill in.
 # Google Gemini API key for the py-help-service GenAI service — https://aistudio.google.com/apikey
+RECIPE_SERVICE_KEY=
 HELP_SERVICE_KEY=
+DB_URL=jdbc:postgresql://ip:5432/cooking
+DB_USER=postgres
+DB_PASSWORD=
+JWT_SECRET=
+JPA_DDL_AUTO=update

--- a/.github/workflows/deploy-help-service.yml
+++ b/.github/workflows/deploy-help-service.yml
@@ -2,7 +2,9 @@ name: Deploy Help Service
 
 on:
   push:
-    paths: ['services/py-help-service/**'] # Only trigger if files in this folder change
+    branches: [main]
+    paths: ['services/py-help-service/**']
+  workflow_dispatch:
 
 jobs:
   # --- Step 1: CI (Quality Check) ---
@@ -25,8 +27,7 @@ jobs:
 
   # --- Step 2: CD (The Scalable Deployment) ---
   call-deploy:
-    needs: [test] 
-    if: github.ref == 'refs/heads/main'
+    needs: [test]
     uses: ./.github/workflows/reusable-deploy.yml
     with:
       service_name: py-help-service

--- a/.github/workflows/deploy-recipe-service.yml
+++ b/.github/workflows/deploy-recipe-service.yml
@@ -2,7 +2,9 @@ name: Deploy Recipe Service
 
 on:
   push:
-    paths: ['services/py-recipe-service/**'] # Only trigger if files in this folder change
+    branches: [main]
+    paths: ['services/py-recipe-service/**']
+  workflow_dispatch:
 
 jobs:
   # --- Step 1: CI (Quality Check) ---
@@ -25,8 +27,7 @@ jobs:
 
   # --- Step 2: CD (The Scalable Deployment) ---
   call-deploy:
-    needs: [test] 
-    if: github.ref == 'refs/heads/main'
+    needs: [test]
     uses: ./.github/workflows/reusable-deploy.yml
     with:
       service_name: py-recipe-service

--- a/.github/workflows/deploy-spring-api.yml
+++ b/.github/workflows/deploy-spring-api.yml
@@ -2,7 +2,9 @@ name: Deploy Spring API
 
 on:
   push:
+    branches: [main]
     paths: ['services/spring-api/**', '.github/workflows/deploy-spring-api.yml']
+  workflow_dispatch:
 
 jobs:
   build:
@@ -21,7 +23,7 @@ jobs:
 
   deploy:
     needs: [build]
-    if: github.ref == 'refs/heads/main'
+    environment: production
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -29,7 +31,7 @@ jobs:
       - name: Google Auth
         uses: 'google-github-actions/auth@v2'
         with:
-          credentials_json: '${{ secrets.GCP_SA_KEY }}'
+          credentials_json: '${{ secrets.API_SA_KEY }}'
 
       - name: Set up Cloud SDK
         uses: 'google-github-actions/setup-gcloud@v2'

--- a/.github/workflows/deploy-spring-api.yml
+++ b/.github/workflows/deploy-spring-api.yml
@@ -48,4 +48,4 @@ jobs:
             --image gcr.io/${{ vars.GCP_PROJECT_ID }}/spring-api:${{ github.sha }} \
             --region us-central1 \
             --allow-unauthenticated \
-            --set-env-vars "AI_HELP_SERVICE_URL=${{ vars.AI_HELP_SERVICE_URL }}"
+            --set-env-vars "AI_HELP_SERVICE_URL=${{ vars.AI_HELP_SERVICE_URL }},AI_RECIPE_SERVICE_URL=${{ vars.AI_RECIPE_SERVICE_URL }},DB_URL=${{ vars.DB_URL }},DB_USER=${{ vars.DB_USER }},DB_PASSWORD=${{ secrets.DB_PASSWORD }},JWT_SECRET=${{ secrets.JWT_SECRET }},JPA_DDL_AUTO=${{ vars.JPA_DDL_AUTO }}"

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -317,24 +317,13 @@ components:
 
     Recipe:
       type: object
-      required: [id, title, ingredients, instructions, portions]
-      properties:
-        id:
-          type: integer
-        title:
-          type: string
-        ingredients:
-          type: array
-          items:
-            $ref: "#/components/schemas/RecipeIngredient"
-        instructions:
-          type: array
-          items:
-            type: string
-        portions:
-          type: integer
-        nutrients:
-          $ref: "#/components/schemas/RecipeNutrients"
+      allOf:
+        - $ref: "#/components/schemas/RecipeInput"
+        - type: object
+          required: [id]
+          properties:
+            id:
+              type: integer
 
     RecipeRequest:
       type: object

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -85,9 +85,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/UserProfile"
-              blacklist:
-                - id
+              $ref: "#/components/schemas/UserProfileUpdate"
       responses:
         "200":
           description: Profile and preferences updated
@@ -130,7 +128,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/Recipe"
+              $ref: "#/components/schemas/RecipeInput"
       responses:
         "201":
           description: Recipe saved
@@ -191,8 +189,8 @@ paths:
     post:
       tags: [AI]
       summary: Ask AI cooking assistant for help
-      # security:
-      #   - bearerAuth: []
+      security:
+        - bearerAuth: []
       requestBody:
         required: true
         content:
@@ -245,49 +243,69 @@ components:
 
     UserProfile:
       type: object
-      required: [id]
+      required: [username, preferences]
       properties:
-        id:
-          type: integer
-          readOnly: true
+        username:
+          type: string
+        preferences:
+          $ref: "#/components/schemas/UserPreferences"
+
+    UserProfileUpdate:
+      type: object
+      properties:
         username:
           type: string
         password:
           type: string
         preferences:
-          type: object
-          properties:
-            diet:
-              type: string
-            allergies:
-              type: array
-              items:
-                type: string
-            aboutMe:
-              type: array
-              items:
-                type: string
+          $ref: "#/components/schemas/UserPreferences"
 
-    Recipe:
+    UserPreferences:
+      type: object
+      properties:
+        diet:
+          type: string
+        allergies:
+          type: array
+          items:
+            type: string
+        aboutMe:
+          type: array
+          items:
+            type: string
+
+    RecipeIngredient:
+      type: object
+      properties:
+        quantity:
+          type: number
+        unit:
+          type: string
+        name:
+          type: string
+
+    RecipeNutrients:
+      type: object
+      properties:
+        calories:
+          type: integer
+        protein:
+          type: integer
+        fat:
+          type: integer
+        carbs:
+          type: integer
+
+    RecipeInput:
       type: object
       required: [title, ingredients, instructions, portions]
       properties:
-        id:
-          type: integer
-          readOnly: true
         title:
           type: string
         ingredients:
           type: array
           items:
-            type: object
-            properties:
-              quantity:
-                type: number
-              unit:
-                type: string
-              name:
-                type: string
+            $ref: "#/components/schemas/RecipeIngredient"
         instructions:
           type: array
           items:
@@ -295,18 +313,37 @@ components:
         portions:
           type: integer
         nutrients:
-          type: object
-          properties:
-            calories:
-              type: integer
-            protein:
-              type: integer
-            fat:
-              type: integer
-            carbs:
-              type: integer
+          $ref: "#/components/schemas/RecipeNutrients"
+
+    Recipe:
+      type: object
+      required: [id, title, ingredients, instructions, portions]
+      properties:
+        id:
+          type: integer
+        title:
+          type: string
+        ingredients:
+          type: array
+          items:
+            $ref: "#/components/schemas/RecipeIngredient"
+        instructions:
+          type: array
+          items:
+            type: string
+        portions:
+          type: integer
+        nutrients:
+          $ref: "#/components/schemas/RecipeNutrients"
 
     RecipeRequest:
+      type: object
+      required: [prompt]
+      properties:
+        prompt:
+          type: string
+
+    RecipeRequestForwarded:
       type: object
       required: [profile,prompt]
       properties:
@@ -317,13 +354,21 @@ components:
 
     HelpRequest:
       type: object
-      # required: [profile,recipe,prompt]
-      required: [prompt]
+      required: [recipe, prompt]
+      properties:
+        recipe:
+          $ref: "#/components/schemas/RecipeInput"
+        prompt:
+          type: string
+
+    HelpRequestForwarded:
+      type: object
+      required: [profile,recipe,prompt]
       properties:
         profile:
           $ref: "#/components/schemas/UserProfile"
         recipe:
-          $ref: "#/components/schemas/Recipe"
+          $ref: "#/components/schemas/RecipeInput"
         prompt:
           type: string
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,25 @@
 services:
+  py-recipe-service:
+    build: ./services/py-recipe-service
+    ports:
+      - "8090:8080"
+    environment:
+      SERVICE_API_KEY: ${RECIPE_SERVICE_KEY}
+    develop:
+      watch:
+        - action: sync+restart
+          path: ./services/py-recipe-service
+          target: /app
+          ignore:
+            - __pycache__/
+            - "*.pyc"
+        - action: rebuild
+          path: ./services/py-recipe-service/requirements.txt
+
   py-help-service:
     build: ./services/py-help-service
     ports:
-      - "8090:8080"
+      - "8091:8080"
     environment:
       SERVICE_API_KEY: ${HELP_SERVICE_KEY}
     develop:
@@ -21,9 +38,16 @@ services:
     ports:
       - "8081:8080"
     environment:
+      AI_RECIPE_SERVICE_URL: http://py-recipe-service:8080
       AI_HELP_SERVICE_URL: http://py-help-service:8080
+      DB_URL: ${DB_URL}
+      DB_USER: ${DB_USER}
+      DB_PASSWORD: ${DB_PASSWORD}
+      JWT_SECRET: ${JWT_SECRET}
+      JPA_DDL_AUTO: ${JPA_DDL_AUTO}
     depends_on:
       - py-help-service
+      - py-recipe-service
     develop:
       watch:
         - action: rebuild

--- a/services/py-help-service/client/cooking_assistant_api_client/api/ai/post_ai_help.py
+++ b/services/py-help-service/client/cooking_assistant_api_client/api/ai/post_ai_help.py
@@ -56,7 +56,7 @@ def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 
 def sync_detailed(
     *,
-    client: AuthenticatedClient | Client,
+    client: AuthenticatedClient,
     body: HelpRequest,
 ) -> Response[Any | HelpResponse]:
     """Ask AI cooking assistant for help
@@ -85,7 +85,7 @@ def sync_detailed(
 
 def sync(
     *,
-    client: AuthenticatedClient | Client,
+    client: AuthenticatedClient,
     body: HelpRequest,
 ) -> Any | HelpResponse | None:
     """Ask AI cooking assistant for help
@@ -109,7 +109,7 @@ def sync(
 
 async def asyncio_detailed(
     *,
-    client: AuthenticatedClient | Client,
+    client: AuthenticatedClient,
     body: HelpRequest,
 ) -> Response[Any | HelpResponse]:
     """Ask AI cooking assistant for help
@@ -136,7 +136,7 @@ async def asyncio_detailed(
 
 async def asyncio(
     *,
-    client: AuthenticatedClient | Client,
+    client: AuthenticatedClient,
     body: HelpRequest,
 ) -> Any | HelpResponse | None:
     """Ask AI cooking assistant for help

--- a/services/py-help-service/client/cooking_assistant_api_client/api/recipes/post_recipes.py
+++ b/services/py-help-service/client/cooking_assistant_api_client/api/recipes/post_recipes.py
@@ -5,13 +5,13 @@ import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...models.recipe import Recipe
+from ...models.recipe_input import RecipeInput
 from ...types import Response
 
 
 def _get_kwargs(
     *,
-    body: Recipe,
+    body: RecipeInput,
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
@@ -53,12 +53,12 @@ def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 def sync_detailed(
     *,
     client: AuthenticatedClient,
-    body: Recipe,
+    body: RecipeInput,
 ) -> Response[Any]:
     """Save a recipe
 
     Args:
-        body (Recipe):
+        body (RecipeInput):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -82,12 +82,12 @@ def sync_detailed(
 async def asyncio_detailed(
     *,
     client: AuthenticatedClient,
-    body: Recipe,
+    body: RecipeInput,
 ) -> Response[Any]:
     """Save a recipe
 
     Args:
-        body (Recipe):
+        body (RecipeInput):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/services/py-help-service/client/cooking_assistant_api_client/api/users/put_users_profile.py
+++ b/services/py-help-service/client/cooking_assistant_api_client/api/users/put_users_profile.py
@@ -5,13 +5,13 @@ import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...models.user_profile import UserProfile
+from ...models.user_profile_update import UserProfileUpdate
 from ...types import Response
 
 
 def _get_kwargs(
     *,
-    body: UserProfile,
+    body: UserProfileUpdate,
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
@@ -59,12 +59,12 @@ def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 def sync_detailed(
     *,
     client: AuthenticatedClient,
-    body: UserProfile,
+    body: UserProfileUpdate,
 ) -> Response[Any]:
     """Update user profile and preferences
 
     Args:
-        body (UserProfile):
+        body (UserProfileUpdate):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -88,12 +88,12 @@ def sync_detailed(
 async def asyncio_detailed(
     *,
     client: AuthenticatedClient,
-    body: UserProfile,
+    body: UserProfileUpdate,
 ) -> Response[Any]:
     """Update user profile and preferences
 
     Args:
-        body (UserProfile):
+        body (UserProfileUpdate):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/services/py-help-service/client/cooking_assistant_api_client/models/__init__.py
+++ b/services/py-help-service/client/cooking_assistant_api_client/models/__init__.py
@@ -1,25 +1,33 @@
 """Contains all the data models used in inputs/outputs"""
 
 from .help_request import HelpRequest
+from .help_request_forwarded import HelpRequestForwarded
 from .help_response import HelpResponse
 from .login_request import LoginRequest
 from .recipe import Recipe
-from .recipe_ingredients_item import RecipeIngredientsItem
+from .recipe_ingredient import RecipeIngredient
+from .recipe_input import RecipeInput
 from .recipe_nutrients import RecipeNutrients
 from .recipe_request import RecipeRequest
+from .recipe_request_forwarded import RecipeRequestForwarded
 from .register_request import RegisterRequest
+from .user_preferences import UserPreferences
 from .user_profile import UserProfile
-from .user_profile_preferences import UserProfilePreferences
+from .user_profile_update import UserProfileUpdate
 
 __all__ = (
     "HelpRequest",
+    "HelpRequestForwarded",
     "HelpResponse",
     "LoginRequest",
     "Recipe",
-    "RecipeIngredientsItem",
+    "RecipeIngredient",
+    "RecipeInput",
     "RecipeNutrients",
     "RecipeRequest",
+    "RecipeRequestForwarded",
     "RegisterRequest",
+    "UserPreferences",
     "UserProfile",
-    "UserProfilePreferences",
+    "UserProfileUpdate",
 )

--- a/services/py-help-service/client/cooking_assistant_api_client/models/help_request.py
+++ b/services/py-help-service/client/cooking_assistant_api_client/models/help_request.py
@@ -6,11 +6,8 @@ from typing import TYPE_CHECKING, Any, TypeVar
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
-from ..types import UNSET, Unset
-
 if TYPE_CHECKING:
-    from ..models.recipe import Recipe
-    from ..models.user_profile import UserProfile
+    from ..models.recipe_input import RecipeInput
 
 
 T = TypeVar("T", bound="HelpRequest")
@@ -20,67 +17,42 @@ T = TypeVar("T", bound="HelpRequest")
 class HelpRequest:
     """
     Attributes:
+        recipe (RecipeInput):
         prompt (str):
-        profile (UserProfile | Unset):
-        recipe (Recipe | Unset):
     """
 
+    recipe: RecipeInput
     prompt: str
-    profile: UserProfile | Unset = UNSET
-    recipe: Recipe | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        recipe = self.recipe.to_dict()
+
         prompt = self.prompt
-
-        profile: dict[str, Any] | Unset = UNSET
-        if not isinstance(self.profile, Unset):
-            profile = self.profile.to_dict()
-
-        recipe: dict[str, Any] | Unset = UNSET
-        if not isinstance(self.recipe, Unset):
-            recipe = self.recipe.to_dict()
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
+                "recipe": recipe,
                 "prompt": prompt,
             }
         )
-        if profile is not UNSET:
-            field_dict["profile"] = profile
-        if recipe is not UNSET:
-            field_dict["recipe"] = recipe
 
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
-        from ..models.recipe import Recipe
-        from ..models.user_profile import UserProfile
+        from ..models.recipe_input import RecipeInput
 
         d = dict(src_dict)
+        recipe = RecipeInput.from_dict(d.pop("recipe"))
+
         prompt = d.pop("prompt")
 
-        _profile = d.pop("profile", UNSET)
-        profile: UserProfile | Unset
-        if isinstance(_profile, Unset):
-            profile = UNSET
-        else:
-            profile = UserProfile.from_dict(_profile)
-
-        _recipe = d.pop("recipe", UNSET)
-        recipe: Recipe | Unset
-        if isinstance(_recipe, Unset):
-            recipe = UNSET
-        else:
-            recipe = Recipe.from_dict(_recipe)
-
         help_request = cls(
-            prompt=prompt,
-            profile=profile,
             recipe=recipe,
+            prompt=prompt,
         )
 
         help_request.additional_properties = d

--- a/services/py-help-service/client/cooking_assistant_api_client/models/help_request_forwarded.py
+++ b/services/py-help-service/client/cooking_assistant_api_client/models/help_request_forwarded.py
@@ -7,35 +7,41 @@ from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
 if TYPE_CHECKING:
-    from ..models.user_preferences import UserPreferences
+    from ..models.recipe_input import RecipeInput
+    from ..models.user_profile import UserProfile
 
 
-T = TypeVar("T", bound="UserProfile")
+T = TypeVar("T", bound="HelpRequestForwarded")
 
 
 @_attrs_define
-class UserProfile:
+class HelpRequestForwarded:
     """
     Attributes:
-        username (str):
-        preferences (UserPreferences):
+        profile (UserProfile):
+        recipe (RecipeInput):
+        prompt (str):
     """
 
-    username: str
-    preferences: UserPreferences
+    profile: UserProfile
+    recipe: RecipeInput
+    prompt: str
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        username = self.username
+        profile = self.profile.to_dict()
 
-        preferences = self.preferences.to_dict()
+        recipe = self.recipe.to_dict()
+
+        prompt = self.prompt
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "username": username,
-                "preferences": preferences,
+                "profile": profile,
+                "recipe": recipe,
+                "prompt": prompt,
             }
         )
 
@@ -43,20 +49,24 @@ class UserProfile:
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
-        from ..models.user_preferences import UserPreferences
+        from ..models.recipe_input import RecipeInput
+        from ..models.user_profile import UserProfile
 
         d = dict(src_dict)
-        username = d.pop("username")
+        profile = UserProfile.from_dict(d.pop("profile"))
 
-        preferences = UserPreferences.from_dict(d.pop("preferences"))
+        recipe = RecipeInput.from_dict(d.pop("recipe"))
 
-        user_profile = cls(
-            username=username,
-            preferences=preferences,
+        prompt = d.pop("prompt")
+
+        help_request_forwarded = cls(
+            profile=profile,
+            recipe=recipe,
+            prompt=prompt,
         )
 
-        user_profile.additional_properties = d
-        return user_profile
+        help_request_forwarded.additional_properties = d
+        return help_request_forwarded
 
     @property
     def additional_keys(self) -> list[str]:

--- a/services/py-help-service/client/cooking_assistant_api_client/models/recipe.py
+++ b/services/py-help-service/client/cooking_assistant_api_client/models/recipe.py
@@ -20,25 +20,23 @@ T = TypeVar("T", bound="Recipe")
 class Recipe:
     """
     Attributes:
-        id (int):
         title (str):
         ingredients (list[RecipeIngredient]):
         instructions (list[str]):
         portions (int):
+        id (int):
         nutrients (RecipeNutrients | Unset):
     """
 
-    id: int
     title: str
     ingredients: list[RecipeIngredient]
     instructions: list[str]
     portions: int
+    id: int
     nutrients: RecipeNutrients | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        id = self.id
-
         title = self.title
 
         ingredients = []
@@ -50,6 +48,8 @@ class Recipe:
 
         portions = self.portions
 
+        id = self.id
+
         nutrients: dict[str, Any] | Unset = UNSET
         if not isinstance(self.nutrients, Unset):
             nutrients = self.nutrients.to_dict()
@@ -58,11 +58,11 @@ class Recipe:
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "id": id,
                 "title": title,
                 "ingredients": ingredients,
                 "instructions": instructions,
                 "portions": portions,
+                "id": id,
             }
         )
         if nutrients is not UNSET:
@@ -76,8 +76,6 @@ class Recipe:
         from ..models.recipe_nutrients import RecipeNutrients
 
         d = dict(src_dict)
-        id = d.pop("id")
-
         title = d.pop("title")
 
         ingredients = []
@@ -91,6 +89,8 @@ class Recipe:
 
         portions = d.pop("portions")
 
+        id = d.pop("id")
+
         _nutrients = d.pop("nutrients", UNSET)
         nutrients: RecipeNutrients | Unset
         if isinstance(_nutrients, Unset):
@@ -99,11 +99,11 @@ class Recipe:
             nutrients = RecipeNutrients.from_dict(_nutrients)
 
         recipe = cls(
-            id=id,
             title=title,
             ingredients=ingredients,
             instructions=instructions,
             portions=portions,
+            id=id,
             nutrients=nutrients,
         )
 

--- a/services/py-help-service/client/cooking_assistant_api_client/models/recipe_ingredient.py
+++ b/services/py-help-service/client/cooking_assistant_api_client/models/recipe_ingredient.py
@@ -8,11 +8,11 @@ from attrs import field as _attrs_field
 
 from ..types import UNSET, Unset
 
-T = TypeVar("T", bound="RecipeIngredientsItem")
+T = TypeVar("T", bound="RecipeIngredient")
 
 
 @_attrs_define
-class RecipeIngredientsItem:
+class RecipeIngredient:
     """
     Attributes:
         quantity (float | Unset):
@@ -53,14 +53,14 @@ class RecipeIngredientsItem:
 
         name = d.pop("name", UNSET)
 
-        recipe_ingredients_item = cls(
+        recipe_ingredient = cls(
             quantity=quantity,
             unit=unit,
             name=name,
         )
 
-        recipe_ingredients_item.additional_properties = d
-        return recipe_ingredients_item
+        recipe_ingredient.additional_properties = d
+        return recipe_ingredient
 
     @property
     def additional_keys(self) -> list[str]:

--- a/services/py-help-service/client/cooking_assistant_api_client/models/recipe_input.py
+++ b/services/py-help-service/client/cooking_assistant_api_client/models/recipe_input.py
@@ -13,14 +13,13 @@ if TYPE_CHECKING:
     from ..models.recipe_nutrients import RecipeNutrients
 
 
-T = TypeVar("T", bound="Recipe")
+T = TypeVar("T", bound="RecipeInput")
 
 
 @_attrs_define
-class Recipe:
+class RecipeInput:
     """
     Attributes:
-        id (int):
         title (str):
         ingredients (list[RecipeIngredient]):
         instructions (list[str]):
@@ -28,7 +27,6 @@ class Recipe:
         nutrients (RecipeNutrients | Unset):
     """
 
-    id: int
     title: str
     ingredients: list[RecipeIngredient]
     instructions: list[str]
@@ -37,8 +35,6 @@ class Recipe:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        id = self.id
-
         title = self.title
 
         ingredients = []
@@ -58,7 +54,6 @@ class Recipe:
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "id": id,
                 "title": title,
                 "ingredients": ingredients,
                 "instructions": instructions,
@@ -76,8 +71,6 @@ class Recipe:
         from ..models.recipe_nutrients import RecipeNutrients
 
         d = dict(src_dict)
-        id = d.pop("id")
-
         title = d.pop("title")
 
         ingredients = []
@@ -98,8 +91,7 @@ class Recipe:
         else:
             nutrients = RecipeNutrients.from_dict(_nutrients)
 
-        recipe = cls(
-            id=id,
+        recipe_input = cls(
             title=title,
             ingredients=ingredients,
             instructions=instructions,
@@ -107,8 +99,8 @@ class Recipe:
             nutrients=nutrients,
         )
 
-        recipe.additional_properties = d
-        return recipe
+        recipe_input.additional_properties = d
+        return recipe_input
 
     @property
     def additional_keys(self) -> list[str]:

--- a/services/py-help-service/client/cooking_assistant_api_client/models/recipe_request.py
+++ b/services/py-help-service/client/cooking_assistant_api_client/models/recipe_request.py
@@ -1,14 +1,10 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
-
-if TYPE_CHECKING:
-    from ..models.user_profile import UserProfile
-
 
 T = TypeVar("T", bound="RecipeRequest")
 
@@ -17,24 +13,19 @@ T = TypeVar("T", bound="RecipeRequest")
 class RecipeRequest:
     """
     Attributes:
-        profile (UserProfile):
         prompt (str):
     """
 
-    profile: UserProfile
     prompt: str
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        profile = self.profile.to_dict()
-
         prompt = self.prompt
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "profile": profile,
                 "prompt": prompt,
             }
         )
@@ -43,15 +34,10 @@ class RecipeRequest:
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
-        from ..models.user_profile import UserProfile
-
         d = dict(src_dict)
-        profile = UserProfile.from_dict(d.pop("profile"))
-
         prompt = d.pop("prompt")
 
         recipe_request = cls(
-            profile=profile,
             prompt=prompt,
         )
 

--- a/services/py-help-service/client/cooking_assistant_api_client/models/recipe_request_forwarded.py
+++ b/services/py-help-service/client/cooking_assistant_api_client/models/recipe_request_forwarded.py
@@ -7,35 +7,35 @@ from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
 if TYPE_CHECKING:
-    from ..models.user_preferences import UserPreferences
+    from ..models.user_profile import UserProfile
 
 
-T = TypeVar("T", bound="UserProfile")
+T = TypeVar("T", bound="RecipeRequestForwarded")
 
 
 @_attrs_define
-class UserProfile:
+class RecipeRequestForwarded:
     """
     Attributes:
-        username (str):
-        preferences (UserPreferences):
+        profile (UserProfile):
+        prompt (str):
     """
 
-    username: str
-    preferences: UserPreferences
+    profile: UserProfile
+    prompt: str
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        username = self.username
+        profile = self.profile.to_dict()
 
-        preferences = self.preferences.to_dict()
+        prompt = self.prompt
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "username": username,
-                "preferences": preferences,
+                "profile": profile,
+                "prompt": prompt,
             }
         )
 
@@ -43,20 +43,20 @@ class UserProfile:
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
-        from ..models.user_preferences import UserPreferences
+        from ..models.user_profile import UserProfile
 
         d = dict(src_dict)
-        username = d.pop("username")
+        profile = UserProfile.from_dict(d.pop("profile"))
 
-        preferences = UserPreferences.from_dict(d.pop("preferences"))
+        prompt = d.pop("prompt")
 
-        user_profile = cls(
-            username=username,
-            preferences=preferences,
+        recipe_request_forwarded = cls(
+            profile=profile,
+            prompt=prompt,
         )
 
-        user_profile.additional_properties = d
-        return user_profile
+        recipe_request_forwarded.additional_properties = d
+        return recipe_request_forwarded
 
     @property
     def additional_keys(self) -> list[str]:

--- a/services/py-help-service/client/cooking_assistant_api_client/models/user_preferences.py
+++ b/services/py-help-service/client/cooking_assistant_api_client/models/user_preferences.py
@@ -8,11 +8,11 @@ from attrs import field as _attrs_field
 
 from ..types import UNSET, Unset
 
-T = TypeVar("T", bound="UserProfilePreferences")
+T = TypeVar("T", bound="UserPreferences")
 
 
 @_attrs_define
-class UserProfilePreferences:
+class UserPreferences:
     """
     Attributes:
         diet (str | Unset):
@@ -57,14 +57,14 @@ class UserProfilePreferences:
 
         about_me = cast(list[str], d.pop("aboutMe", UNSET))
 
-        user_profile_preferences = cls(
+        user_preferences = cls(
             diet=diet,
             allergies=allergies,
             about_me=about_me,
         )
 
-        user_profile_preferences.additional_properties = d
-        return user_profile_preferences
+        user_preferences.additional_properties = d
+        return user_preferences
 
     @property
     def additional_keys(self) -> list[str]:

--- a/services/py-help-service/client/cooking_assistant_api_client/models/user_profile_update.py
+++ b/services/py-help-service/client/cooking_assistant_api_client/models/user_profile_update.py
@@ -6,38 +6,47 @@ from typing import TYPE_CHECKING, Any, TypeVar
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
+from ..types import UNSET, Unset
+
 if TYPE_CHECKING:
     from ..models.user_preferences import UserPreferences
 
 
-T = TypeVar("T", bound="UserProfile")
+T = TypeVar("T", bound="UserProfileUpdate")
 
 
 @_attrs_define
-class UserProfile:
+class UserProfileUpdate:
     """
     Attributes:
-        username (str):
-        preferences (UserPreferences):
+        username (str | Unset):
+        password (str | Unset):
+        preferences (UserPreferences | Unset):
     """
 
-    username: str
-    preferences: UserPreferences
+    username: str | Unset = UNSET
+    password: str | Unset = UNSET
+    preferences: UserPreferences | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         username = self.username
 
-        preferences = self.preferences.to_dict()
+        password = self.password
+
+        preferences: dict[str, Any] | Unset = UNSET
+        if not isinstance(self.preferences, Unset):
+            preferences = self.preferences.to_dict()
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "username": username,
-                "preferences": preferences,
-            }
-        )
+        field_dict.update({})
+        if username is not UNSET:
+            field_dict["username"] = username
+        if password is not UNSET:
+            field_dict["password"] = password
+        if preferences is not UNSET:
+            field_dict["preferences"] = preferences
 
         return field_dict
 
@@ -46,17 +55,25 @@ class UserProfile:
         from ..models.user_preferences import UserPreferences
 
         d = dict(src_dict)
-        username = d.pop("username")
+        username = d.pop("username", UNSET)
 
-        preferences = UserPreferences.from_dict(d.pop("preferences"))
+        password = d.pop("password", UNSET)
 
-        user_profile = cls(
+        _preferences = d.pop("preferences", UNSET)
+        preferences: UserPreferences | Unset
+        if isinstance(_preferences, Unset):
+            preferences = UNSET
+        else:
+            preferences = UserPreferences.from_dict(_preferences)
+
+        user_profile_update = cls(
             username=username,
+            password=password,
             preferences=preferences,
         )
 
-        user_profile.additional_properties = d
-        return user_profile
+        user_profile_update.additional_properties = d
+        return user_profile_update
 
     @property
     def additional_keys(self) -> list[str]:

--- a/services/py-help-service/main.py
+++ b/services/py-help-service/main.py
@@ -5,7 +5,7 @@ from dotenv import load_dotenv
 from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain_core.messages import HumanMessage, SystemMessage
 
-from client.cooking_assistant_api_client.models.help_request import HelpRequest
+from client.cooking_assistant_api_client.models.help_request_forwarded import HelpRequestForwarded
 from client.cooking_assistant_api_client.models.help_response import HelpResponse
 
 # Load variables from .env for local testing
@@ -26,7 +26,7 @@ def health_check():
 async def generate_help(request_data: dict[str, Any]):
     
     try:
-        request = HelpRequest.from_dict(request_data)
+        request = HelpRequestForwarded.from_dict(request_data)
     except Exception as e:
         raise HTTPException(status_code=400, detail=f"Invalid request format: {str(e)}")
     

--- a/services/py-recipe-service/client/cooking_assistant_api_client/api/ai/post_ai_help.py
+++ b/services/py-recipe-service/client/cooking_assistant_api_client/api/ai/post_ai_help.py
@@ -56,7 +56,7 @@ def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 
 def sync_detailed(
     *,
-    client: AuthenticatedClient | Client,
+    client: AuthenticatedClient,
     body: HelpRequest,
 ) -> Response[Any | HelpResponse]:
     """Ask AI cooking assistant for help
@@ -85,7 +85,7 @@ def sync_detailed(
 
 def sync(
     *,
-    client: AuthenticatedClient | Client,
+    client: AuthenticatedClient,
     body: HelpRequest,
 ) -> Any | HelpResponse | None:
     """Ask AI cooking assistant for help
@@ -109,7 +109,7 @@ def sync(
 
 async def asyncio_detailed(
     *,
-    client: AuthenticatedClient | Client,
+    client: AuthenticatedClient,
     body: HelpRequest,
 ) -> Response[Any | HelpResponse]:
     """Ask AI cooking assistant for help
@@ -136,7 +136,7 @@ async def asyncio_detailed(
 
 async def asyncio(
     *,
-    client: AuthenticatedClient | Client,
+    client: AuthenticatedClient,
     body: HelpRequest,
 ) -> Any | HelpResponse | None:
     """Ask AI cooking assistant for help

--- a/services/py-recipe-service/client/cooking_assistant_api_client/api/recipes/post_recipes.py
+++ b/services/py-recipe-service/client/cooking_assistant_api_client/api/recipes/post_recipes.py
@@ -5,13 +5,13 @@ import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...models.recipe import Recipe
+from ...models.recipe_input import RecipeInput
 from ...types import Response
 
 
 def _get_kwargs(
     *,
-    body: Recipe,
+    body: RecipeInput,
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
@@ -53,12 +53,12 @@ def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 def sync_detailed(
     *,
     client: AuthenticatedClient,
-    body: Recipe,
+    body: RecipeInput,
 ) -> Response[Any]:
     """Save a recipe
 
     Args:
-        body (Recipe):
+        body (RecipeInput):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -82,12 +82,12 @@ def sync_detailed(
 async def asyncio_detailed(
     *,
     client: AuthenticatedClient,
-    body: Recipe,
+    body: RecipeInput,
 ) -> Response[Any]:
     """Save a recipe
 
     Args:
-        body (Recipe):
+        body (RecipeInput):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/services/py-recipe-service/client/cooking_assistant_api_client/api/users/put_users_profile.py
+++ b/services/py-recipe-service/client/cooking_assistant_api_client/api/users/put_users_profile.py
@@ -5,13 +5,13 @@ import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...models.user_profile import UserProfile
+from ...models.user_profile_update import UserProfileUpdate
 from ...types import Response
 
 
 def _get_kwargs(
     *,
-    body: UserProfile,
+    body: UserProfileUpdate,
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
@@ -59,12 +59,12 @@ def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 def sync_detailed(
     *,
     client: AuthenticatedClient,
-    body: UserProfile,
+    body: UserProfileUpdate,
 ) -> Response[Any]:
     """Update user profile and preferences
 
     Args:
-        body (UserProfile):
+        body (UserProfileUpdate):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -88,12 +88,12 @@ def sync_detailed(
 async def asyncio_detailed(
     *,
     client: AuthenticatedClient,
-    body: UserProfile,
+    body: UserProfileUpdate,
 ) -> Response[Any]:
     """Update user profile and preferences
 
     Args:
-        body (UserProfile):
+        body (UserProfileUpdate):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/services/py-recipe-service/client/cooking_assistant_api_client/models/__init__.py
+++ b/services/py-recipe-service/client/cooking_assistant_api_client/models/__init__.py
@@ -1,25 +1,33 @@
 """Contains all the data models used in inputs/outputs"""
 
 from .help_request import HelpRequest
+from .help_request_forwarded import HelpRequestForwarded
 from .help_response import HelpResponse
 from .login_request import LoginRequest
 from .recipe import Recipe
-from .recipe_ingredients_item import RecipeIngredientsItem
+from .recipe_ingredient import RecipeIngredient
+from .recipe_input import RecipeInput
 from .recipe_nutrients import RecipeNutrients
 from .recipe_request import RecipeRequest
+from .recipe_request_forwarded import RecipeRequestForwarded
 from .register_request import RegisterRequest
+from .user_preferences import UserPreferences
 from .user_profile import UserProfile
-from .user_profile_preferences import UserProfilePreferences
+from .user_profile_update import UserProfileUpdate
 
 __all__ = (
     "HelpRequest",
+    "HelpRequestForwarded",
     "HelpResponse",
     "LoginRequest",
     "Recipe",
-    "RecipeIngredientsItem",
+    "RecipeIngredient",
+    "RecipeInput",
     "RecipeNutrients",
     "RecipeRequest",
+    "RecipeRequestForwarded",
     "RegisterRequest",
+    "UserPreferences",
     "UserProfile",
-    "UserProfilePreferences",
+    "UserProfileUpdate",
 )

--- a/services/py-recipe-service/client/cooking_assistant_api_client/models/help_request.py
+++ b/services/py-recipe-service/client/cooking_assistant_api_client/models/help_request.py
@@ -6,11 +6,8 @@ from typing import TYPE_CHECKING, Any, TypeVar
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
-from ..types import UNSET, Unset
-
 if TYPE_CHECKING:
-    from ..models.recipe import Recipe
-    from ..models.user_profile import UserProfile
+    from ..models.recipe_input import RecipeInput
 
 
 T = TypeVar("T", bound="HelpRequest")
@@ -20,67 +17,42 @@ T = TypeVar("T", bound="HelpRequest")
 class HelpRequest:
     """
     Attributes:
+        recipe (RecipeInput):
         prompt (str):
-        profile (UserProfile | Unset):
-        recipe (Recipe | Unset):
     """
 
+    recipe: RecipeInput
     prompt: str
-    profile: UserProfile | Unset = UNSET
-    recipe: Recipe | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        recipe = self.recipe.to_dict()
+
         prompt = self.prompt
-
-        profile: dict[str, Any] | Unset = UNSET
-        if not isinstance(self.profile, Unset):
-            profile = self.profile.to_dict()
-
-        recipe: dict[str, Any] | Unset = UNSET
-        if not isinstance(self.recipe, Unset):
-            recipe = self.recipe.to_dict()
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
+                "recipe": recipe,
                 "prompt": prompt,
             }
         )
-        if profile is not UNSET:
-            field_dict["profile"] = profile
-        if recipe is not UNSET:
-            field_dict["recipe"] = recipe
 
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
-        from ..models.recipe import Recipe
-        from ..models.user_profile import UserProfile
+        from ..models.recipe_input import RecipeInput
 
         d = dict(src_dict)
+        recipe = RecipeInput.from_dict(d.pop("recipe"))
+
         prompt = d.pop("prompt")
 
-        _profile = d.pop("profile", UNSET)
-        profile: UserProfile | Unset
-        if isinstance(_profile, Unset):
-            profile = UNSET
-        else:
-            profile = UserProfile.from_dict(_profile)
-
-        _recipe = d.pop("recipe", UNSET)
-        recipe: Recipe | Unset
-        if isinstance(_recipe, Unset):
-            recipe = UNSET
-        else:
-            recipe = Recipe.from_dict(_recipe)
-
         help_request = cls(
-            prompt=prompt,
-            profile=profile,
             recipe=recipe,
+            prompt=prompt,
         )
 
         help_request.additional_properties = d

--- a/services/py-recipe-service/client/cooking_assistant_api_client/models/help_request_forwarded.py
+++ b/services/py-recipe-service/client/cooking_assistant_api_client/models/help_request_forwarded.py
@@ -7,35 +7,41 @@ from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
 if TYPE_CHECKING:
-    from ..models.user_preferences import UserPreferences
+    from ..models.recipe_input import RecipeInput
+    from ..models.user_profile import UserProfile
 
 
-T = TypeVar("T", bound="UserProfile")
+T = TypeVar("T", bound="HelpRequestForwarded")
 
 
 @_attrs_define
-class UserProfile:
+class HelpRequestForwarded:
     """
     Attributes:
-        username (str):
-        preferences (UserPreferences):
+        profile (UserProfile):
+        recipe (RecipeInput):
+        prompt (str):
     """
 
-    username: str
-    preferences: UserPreferences
+    profile: UserProfile
+    recipe: RecipeInput
+    prompt: str
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        username = self.username
+        profile = self.profile.to_dict()
 
-        preferences = self.preferences.to_dict()
+        recipe = self.recipe.to_dict()
+
+        prompt = self.prompt
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "username": username,
-                "preferences": preferences,
+                "profile": profile,
+                "recipe": recipe,
+                "prompt": prompt,
             }
         )
 
@@ -43,20 +49,24 @@ class UserProfile:
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
-        from ..models.user_preferences import UserPreferences
+        from ..models.recipe_input import RecipeInput
+        from ..models.user_profile import UserProfile
 
         d = dict(src_dict)
-        username = d.pop("username")
+        profile = UserProfile.from_dict(d.pop("profile"))
 
-        preferences = UserPreferences.from_dict(d.pop("preferences"))
+        recipe = RecipeInput.from_dict(d.pop("recipe"))
 
-        user_profile = cls(
-            username=username,
-            preferences=preferences,
+        prompt = d.pop("prompt")
+
+        help_request_forwarded = cls(
+            profile=profile,
+            recipe=recipe,
+            prompt=prompt,
         )
 
-        user_profile.additional_properties = d
-        return user_profile
+        help_request_forwarded.additional_properties = d
+        return help_request_forwarded
 
     @property
     def additional_keys(self) -> list[str]:

--- a/services/py-recipe-service/client/cooking_assistant_api_client/models/recipe.py
+++ b/services/py-recipe-service/client/cooking_assistant_api_client/models/recipe.py
@@ -9,7 +9,7 @@ from attrs import field as _attrs_field
 from ..types import UNSET, Unset
 
 if TYPE_CHECKING:
-    from ..models.recipe_ingredients_item import RecipeIngredientsItem
+    from ..models.recipe_ingredient import RecipeIngredient
     from ..models.recipe_nutrients import RecipeNutrients
 
 
@@ -20,23 +20,25 @@ T = TypeVar("T", bound="Recipe")
 class Recipe:
     """
     Attributes:
+        id (int):
         title (str):
-        ingredients (list[RecipeIngredientsItem]):
+        ingredients (list[RecipeIngredient]):
         instructions (list[str]):
         portions (int):
-        id (int | Unset):
         nutrients (RecipeNutrients | Unset):
     """
 
+    id: int
     title: str
-    ingredients: list[RecipeIngredientsItem]
+    ingredients: list[RecipeIngredient]
     instructions: list[str]
     portions: int
-    id: int | Unset = UNSET
     nutrients: RecipeNutrients | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        id = self.id
+
         title = self.title
 
         ingredients = []
@@ -48,8 +50,6 @@ class Recipe:
 
         portions = self.portions
 
-        id = self.id
-
         nutrients: dict[str, Any] | Unset = UNSET
         if not isinstance(self.nutrients, Unset):
             nutrients = self.nutrients.to_dict()
@@ -58,14 +58,13 @@ class Recipe:
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
+                "id": id,
                 "title": title,
                 "ingredients": ingredients,
                 "instructions": instructions,
                 "portions": portions,
             }
         )
-        if id is not UNSET:
-            field_dict["id"] = id
         if nutrients is not UNSET:
             field_dict["nutrients"] = nutrients
 
@@ -73,24 +72,24 @@ class Recipe:
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
-        from ..models.recipe_ingredients_item import RecipeIngredientsItem
+        from ..models.recipe_ingredient import RecipeIngredient
         from ..models.recipe_nutrients import RecipeNutrients
 
         d = dict(src_dict)
+        id = d.pop("id")
+
         title = d.pop("title")
 
         ingredients = []
         _ingredients = d.pop("ingredients")
         for ingredients_item_data in _ingredients:
-            ingredients_item = RecipeIngredientsItem.from_dict(ingredients_item_data)
+            ingredients_item = RecipeIngredient.from_dict(ingredients_item_data)
 
             ingredients.append(ingredients_item)
 
         instructions = cast(list[str], d.pop("instructions"))
 
         portions = d.pop("portions")
-
-        id = d.pop("id", UNSET)
 
         _nutrients = d.pop("nutrients", UNSET)
         nutrients: RecipeNutrients | Unset
@@ -100,11 +99,11 @@ class Recipe:
             nutrients = RecipeNutrients.from_dict(_nutrients)
 
         recipe = cls(
+            id=id,
             title=title,
             ingredients=ingredients,
             instructions=instructions,
             portions=portions,
-            id=id,
             nutrients=nutrients,
         )
 

--- a/services/py-recipe-service/client/cooking_assistant_api_client/models/recipe.py
+++ b/services/py-recipe-service/client/cooking_assistant_api_client/models/recipe.py
@@ -20,25 +20,23 @@ T = TypeVar("T", bound="Recipe")
 class Recipe:
     """
     Attributes:
-        id (int):
         title (str):
         ingredients (list[RecipeIngredient]):
         instructions (list[str]):
         portions (int):
+        id (int):
         nutrients (RecipeNutrients | Unset):
     """
 
-    id: int
     title: str
     ingredients: list[RecipeIngredient]
     instructions: list[str]
     portions: int
+    id: int
     nutrients: RecipeNutrients | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        id = self.id
-
         title = self.title
 
         ingredients = []
@@ -50,6 +48,8 @@ class Recipe:
 
         portions = self.portions
 
+        id = self.id
+
         nutrients: dict[str, Any] | Unset = UNSET
         if not isinstance(self.nutrients, Unset):
             nutrients = self.nutrients.to_dict()
@@ -58,11 +58,11 @@ class Recipe:
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "id": id,
                 "title": title,
                 "ingredients": ingredients,
                 "instructions": instructions,
                 "portions": portions,
+                "id": id,
             }
         )
         if nutrients is not UNSET:
@@ -76,8 +76,6 @@ class Recipe:
         from ..models.recipe_nutrients import RecipeNutrients
 
         d = dict(src_dict)
-        id = d.pop("id")
-
         title = d.pop("title")
 
         ingredients = []
@@ -91,6 +89,8 @@ class Recipe:
 
         portions = d.pop("portions")
 
+        id = d.pop("id")
+
         _nutrients = d.pop("nutrients", UNSET)
         nutrients: RecipeNutrients | Unset
         if isinstance(_nutrients, Unset):
@@ -99,11 +99,11 @@ class Recipe:
             nutrients = RecipeNutrients.from_dict(_nutrients)
 
         recipe = cls(
-            id=id,
             title=title,
             ingredients=ingredients,
             instructions=instructions,
             portions=portions,
+            id=id,
             nutrients=nutrients,
         )
 

--- a/services/py-recipe-service/client/cooking_assistant_api_client/models/recipe_ingredient.py
+++ b/services/py-recipe-service/client/cooking_assistant_api_client/models/recipe_ingredient.py
@@ -8,11 +8,11 @@ from attrs import field as _attrs_field
 
 from ..types import UNSET, Unset
 
-T = TypeVar("T", bound="RecipeIngredientsItem")
+T = TypeVar("T", bound="RecipeIngredient")
 
 
 @_attrs_define
-class RecipeIngredientsItem:
+class RecipeIngredient:
     """
     Attributes:
         quantity (float | Unset):
@@ -53,14 +53,14 @@ class RecipeIngredientsItem:
 
         name = d.pop("name", UNSET)
 
-        recipe_ingredients_item = cls(
+        recipe_ingredient = cls(
             quantity=quantity,
             unit=unit,
             name=name,
         )
 
-        recipe_ingredients_item.additional_properties = d
-        return recipe_ingredients_item
+        recipe_ingredient.additional_properties = d
+        return recipe_ingredient
 
     @property
     def additional_keys(self) -> list[str]:

--- a/services/py-recipe-service/client/cooking_assistant_api_client/models/recipe_input.py
+++ b/services/py-recipe-service/client/cooking_assistant_api_client/models/recipe_input.py
@@ -13,14 +13,13 @@ if TYPE_CHECKING:
     from ..models.recipe_nutrients import RecipeNutrients
 
 
-T = TypeVar("T", bound="Recipe")
+T = TypeVar("T", bound="RecipeInput")
 
 
 @_attrs_define
-class Recipe:
+class RecipeInput:
     """
     Attributes:
-        id (int):
         title (str):
         ingredients (list[RecipeIngredient]):
         instructions (list[str]):
@@ -28,7 +27,6 @@ class Recipe:
         nutrients (RecipeNutrients | Unset):
     """
 
-    id: int
     title: str
     ingredients: list[RecipeIngredient]
     instructions: list[str]
@@ -37,8 +35,6 @@ class Recipe:
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        id = self.id
-
         title = self.title
 
         ingredients = []
@@ -58,7 +54,6 @@ class Recipe:
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "id": id,
                 "title": title,
                 "ingredients": ingredients,
                 "instructions": instructions,
@@ -76,8 +71,6 @@ class Recipe:
         from ..models.recipe_nutrients import RecipeNutrients
 
         d = dict(src_dict)
-        id = d.pop("id")
-
         title = d.pop("title")
 
         ingredients = []
@@ -98,8 +91,7 @@ class Recipe:
         else:
             nutrients = RecipeNutrients.from_dict(_nutrients)
 
-        recipe = cls(
-            id=id,
+        recipe_input = cls(
             title=title,
             ingredients=ingredients,
             instructions=instructions,
@@ -107,8 +99,8 @@ class Recipe:
             nutrients=nutrients,
         )
 
-        recipe.additional_properties = d
-        return recipe
+        recipe_input.additional_properties = d
+        return recipe_input
 
     @property
     def additional_keys(self) -> list[str]:

--- a/services/py-recipe-service/client/cooking_assistant_api_client/models/recipe_request.py
+++ b/services/py-recipe-service/client/cooking_assistant_api_client/models/recipe_request.py
@@ -1,14 +1,10 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
-
-if TYPE_CHECKING:
-    from ..models.user_profile import UserProfile
-
 
 T = TypeVar("T", bound="RecipeRequest")
 
@@ -17,24 +13,19 @@ T = TypeVar("T", bound="RecipeRequest")
 class RecipeRequest:
     """
     Attributes:
-        profile (UserProfile):
         prompt (str):
     """
 
-    profile: UserProfile
     prompt: str
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        profile = self.profile.to_dict()
-
         prompt = self.prompt
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "profile": profile,
                 "prompt": prompt,
             }
         )
@@ -43,15 +34,10 @@ class RecipeRequest:
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
-        from ..models.user_profile import UserProfile
-
         d = dict(src_dict)
-        profile = UserProfile.from_dict(d.pop("profile"))
-
         prompt = d.pop("prompt")
 
         recipe_request = cls(
-            profile=profile,
             prompt=prompt,
         )
 

--- a/services/py-recipe-service/client/cooking_assistant_api_client/models/recipe_request_forwarded.py
+++ b/services/py-recipe-service/client/cooking_assistant_api_client/models/recipe_request_forwarded.py
@@ -7,35 +7,35 @@ from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
 if TYPE_CHECKING:
-    from ..models.user_preferences import UserPreferences
+    from ..models.user_profile import UserProfile
 
 
-T = TypeVar("T", bound="UserProfile")
+T = TypeVar("T", bound="RecipeRequestForwarded")
 
 
 @_attrs_define
-class UserProfile:
+class RecipeRequestForwarded:
     """
     Attributes:
-        username (str):
-        preferences (UserPreferences):
+        profile (UserProfile):
+        prompt (str):
     """
 
-    username: str
-    preferences: UserPreferences
+    profile: UserProfile
+    prompt: str
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        username = self.username
+        profile = self.profile.to_dict()
 
-        preferences = self.preferences.to_dict()
+        prompt = self.prompt
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "username": username,
-                "preferences": preferences,
+                "profile": profile,
+                "prompt": prompt,
             }
         )
 
@@ -43,20 +43,20 @@ class UserProfile:
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
-        from ..models.user_preferences import UserPreferences
+        from ..models.user_profile import UserProfile
 
         d = dict(src_dict)
-        username = d.pop("username")
+        profile = UserProfile.from_dict(d.pop("profile"))
 
-        preferences = UserPreferences.from_dict(d.pop("preferences"))
+        prompt = d.pop("prompt")
 
-        user_profile = cls(
-            username=username,
-            preferences=preferences,
+        recipe_request_forwarded = cls(
+            profile=profile,
+            prompt=prompt,
         )
 
-        user_profile.additional_properties = d
-        return user_profile
+        recipe_request_forwarded.additional_properties = d
+        return recipe_request_forwarded
 
     @property
     def additional_keys(self) -> list[str]:

--- a/services/py-recipe-service/client/cooking_assistant_api_client/models/user_preferences.py
+++ b/services/py-recipe-service/client/cooking_assistant_api_client/models/user_preferences.py
@@ -8,11 +8,11 @@ from attrs import field as _attrs_field
 
 from ..types import UNSET, Unset
 
-T = TypeVar("T", bound="UserProfilePreferences")
+T = TypeVar("T", bound="UserPreferences")
 
 
 @_attrs_define
-class UserProfilePreferences:
+class UserPreferences:
     """
     Attributes:
         diet (str | Unset):
@@ -57,14 +57,14 @@ class UserProfilePreferences:
 
         about_me = cast(list[str], d.pop("aboutMe", UNSET))
 
-        user_profile_preferences = cls(
+        user_preferences = cls(
             diet=diet,
             allergies=allergies,
             about_me=about_me,
         )
 
-        user_profile_preferences.additional_properties = d
-        return user_profile_preferences
+        user_preferences.additional_properties = d
+        return user_preferences
 
     @property
     def additional_keys(self) -> list[str]:

--- a/services/py-recipe-service/client/cooking_assistant_api_client/models/user_profile.py
+++ b/services/py-recipe-service/client/cooking_assistant_api_client/models/user_profile.py
@@ -6,10 +6,8 @@ from typing import TYPE_CHECKING, Any, TypeVar
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
-from ..types import UNSET, Unset
-
 if TYPE_CHECKING:
-    from ..models.user_profile_preferences import UserProfilePreferences
+    from ..models.user_preferences import UserPreferences
 
 
 T = TypeVar("T", bound="UserProfile")
@@ -19,67 +17,41 @@ T = TypeVar("T", bound="UserProfile")
 class UserProfile:
     """
     Attributes:
-        id (int):
-        username (str | Unset):
-        password (str | Unset):
-        preferences (UserProfilePreferences | Unset):
+        username (str):
+        preferences (UserPreferences):
     """
 
-    id: int
-    username: str | Unset = UNSET
-    password: str | Unset = UNSET
-    preferences: UserProfilePreferences | Unset = UNSET
+    username: str
+    preferences: UserPreferences
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        id = self.id
-
         username = self.username
 
-        password = self.password
-
-        preferences: dict[str, Any] | Unset = UNSET
-        if not isinstance(self.preferences, Unset):
-            preferences = self.preferences.to_dict()
+        preferences = self.preferences.to_dict()
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "id": id,
+                "username": username,
+                "preferences": preferences,
             }
         )
-        if username is not UNSET:
-            field_dict["username"] = username
-        if password is not UNSET:
-            field_dict["password"] = password
-        if preferences is not UNSET:
-            field_dict["preferences"] = preferences
 
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
-        from ..models.user_profile_preferences import UserProfilePreferences
+        from ..models.user_preferences import UserPreferences
 
         d = dict(src_dict)
-        id = d.pop("id")
+        username = d.pop("username")
 
-        username = d.pop("username", UNSET)
-
-        password = d.pop("password", UNSET)
-
-        _preferences = d.pop("preferences", UNSET)
-        preferences: UserProfilePreferences | Unset
-        if isinstance(_preferences, Unset):
-            preferences = UNSET
-        else:
-            preferences = UserProfilePreferences.from_dict(_preferences)
+        preferences = UserPreferences.from_dict(d.pop("preferences"))
 
         user_profile = cls(
-            id=id,
             username=username,
-            password=password,
             preferences=preferences,
         )
 

--- a/services/py-recipe-service/client/cooking_assistant_api_client/models/user_profile_update.py
+++ b/services/py-recipe-service/client/cooking_assistant_api_client/models/user_profile_update.py
@@ -6,38 +6,47 @@ from typing import TYPE_CHECKING, Any, TypeVar
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
+from ..types import UNSET, Unset
+
 if TYPE_CHECKING:
     from ..models.user_preferences import UserPreferences
 
 
-T = TypeVar("T", bound="UserProfile")
+T = TypeVar("T", bound="UserProfileUpdate")
 
 
 @_attrs_define
-class UserProfile:
+class UserProfileUpdate:
     """
     Attributes:
-        username (str):
-        preferences (UserPreferences):
+        username (str | Unset):
+        password (str | Unset):
+        preferences (UserPreferences | Unset):
     """
 
-    username: str
-    preferences: UserPreferences
+    username: str | Unset = UNSET
+    password: str | Unset = UNSET
+    preferences: UserPreferences | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         username = self.username
 
-        preferences = self.preferences.to_dict()
+        password = self.password
+
+        preferences: dict[str, Any] | Unset = UNSET
+        if not isinstance(self.preferences, Unset):
+            preferences = self.preferences.to_dict()
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        field_dict.update(
-            {
-                "username": username,
-                "preferences": preferences,
-            }
-        )
+        field_dict.update({})
+        if username is not UNSET:
+            field_dict["username"] = username
+        if password is not UNSET:
+            field_dict["password"] = password
+        if preferences is not UNSET:
+            field_dict["preferences"] = preferences
 
         return field_dict
 
@@ -46,17 +55,25 @@ class UserProfile:
         from ..models.user_preferences import UserPreferences
 
         d = dict(src_dict)
-        username = d.pop("username")
+        username = d.pop("username", UNSET)
 
-        preferences = UserPreferences.from_dict(d.pop("preferences"))
+        password = d.pop("password", UNSET)
 
-        user_profile = cls(
+        _preferences = d.pop("preferences", UNSET)
+        preferences: UserPreferences | Unset
+        if isinstance(_preferences, Unset):
+            preferences = UNSET
+        else:
+            preferences = UserPreferences.from_dict(_preferences)
+
+        user_profile_update = cls(
             username=username,
+            password=password,
             preferences=preferences,
         )
 
-        user_profile.additional_properties = d
-        return user_profile
+        user_profile_update.additional_properties = d
+        return user_profile_update
 
     @property
     def additional_keys(self) -> list[str]:

--- a/services/py-recipe-service/main.py
+++ b/services/py-recipe-service/main.py
@@ -6,8 +6,7 @@ from dotenv import load_dotenv
 from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain_core.messages import HumanMessage, SystemMessage
 
-from client.cooking_assistant_api_client.models.recipe_request import RecipeRequest
-from client.cooking_assistant_api_client.models.recipe import Recipe
+from client.cooking_assistant_api_client.models.recipe_request_forwarded import RecipeRequestForwarded
 
 # Load variables from .env for local testing
 load_dotenv()
@@ -28,7 +27,7 @@ async def generate_recipes(request_data: dict[str, Any]):
     try:
 
         try:
-            request = RecipeRequest.from_dict(request_data)
+            request = RecipeRequestForwarded.from_dict(request_data)
         except Exception as e:
             raise HTTPException(status_code=400, detail=f"Invalid request format: {str(e)}")
 
@@ -67,8 +66,7 @@ async def generate_recipes(request_data: dict[str, Any]):
         clean_json = response.content.strip().removeprefix("```json").removesuffix("```").strip()
         data = json.loads(clean_json)
 
-        recipe_obj = Recipe.from_dict(data) 
-        return recipe_obj.to_dict()
+        return data
 
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))

--- a/services/spring-api/.openapi-generator/FILES
+++ b/services/spring-api/.openapi-generator/FILES
@@ -12,11 +12,16 @@ src/main/kotlin/org/openapitools/api/Exceptions.kt
 src/main/kotlin/org/openapitools/api/RecipesApi.kt
 src/main/kotlin/org/openapitools/api/UsersApi.kt
 src/main/kotlin/org/openapitools/model/HelpRequest.kt
+src/main/kotlin/org/openapitools/model/HelpRequestForwarded.kt
 src/main/kotlin/org/openapitools/model/HelpResponse.kt
 src/main/kotlin/org/openapitools/model/LoginRequest.kt
 src/main/kotlin/org/openapitools/model/Recipe.kt
+src/main/kotlin/org/openapitools/model/RecipeIngredient.kt
+src/main/kotlin/org/openapitools/model/RecipeInput.kt
 src/main/kotlin/org/openapitools/model/RecipeNutrients.kt
 src/main/kotlin/org/openapitools/model/RecipeRequest.kt
+src/main/kotlin/org/openapitools/model/RecipeRequestForwarded.kt
 src/main/kotlin/org/openapitools/model/RegisterRequest.kt
+src/main/kotlin/org/openapitools/model/UserPreferences.kt
 src/main/kotlin/org/openapitools/model/UserProfile.kt
-src/main/kotlin/org/openapitools/model/UserProfilePreferences.kt
+src/main/kotlin/org/openapitools/model/UserProfileUpdate.kt

--- a/services/spring-api/build.gradle.kts
+++ b/services/spring-api/build.gradle.kts
@@ -43,6 +43,18 @@ dependencies {
 
     implementation("org.springframework.boot:spring-boot-starter-webflux")
 
+    // Database
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    runtimeOnly("com.h2database:h2")
+    runtimeOnly("org.postgresql:postgresql")
+    runtimeOnly("com.google.cloud.sql:postgres-socket-factory:1.21.0")
+
+    // Auth
+    implementation("org.springframework.boot:spring-boot-starter-security")
+    implementation("io.jsonwebtoken:jjwt-api:0.12.6")
+    runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.6")
+    runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.6")
+
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testImplementation("org.springframework.boot:spring-boot-starter-test") {
         exclude(module = "junit")

--- a/services/spring-api/src/main/kotlin/org/openapitools/api/AIApi.kt
+++ b/services/spring-api/src/main/kotlin/org/openapitools/api/AIApi.kt
@@ -21,6 +21,7 @@ import jakarta.validation.constraints.Pattern
 import jakarta.validation.constraints.Size
 import org.openapitools.model.HelpRequest
 import org.openapitools.model.HelpResponse
+import org.openapitools.model.Recipe
 import org.openapitools.model.RecipeRequest
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
@@ -46,7 +47,9 @@ interface AIApi {
 				description = "AI response",
 				content = [Content(schema = Schema(implementation = HelpResponse::class))],
 			),
+			ApiResponse(responseCode = "403", description = "Not logged in"),
 		],
+		security = [ SecurityRequirement(name = "bearerAuth") ],
 	)
 	@RequestMapping(
 		method = [RequestMethod.POST],
@@ -65,7 +68,12 @@ interface AIApi {
 		operationId = "aiRecipesPost",
 		description = """""",
 		responses = [
-			ApiResponse(responseCode = "200", description = "Generated recipes"),
+			ApiResponse(
+				responseCode = "200",
+				description = "Generated recipes",
+				content = [Content(array = ArraySchema(schema = Schema(implementation = Recipe::class)))],
+			),
+			ApiResponse(responseCode = "403", description = "Not logged in"),
 		],
 		security = [ SecurityRequirement(name = "bearerAuth") ],
 	)
@@ -73,11 +81,12 @@ interface AIApi {
 		method = [RequestMethod.POST],
 		// "/ai/recipes"
 		value = [PATH_AI_RECIPES_POST],
+		produces = ["application/json"],
 		consumes = ["application/json"],
 	)
 	fun aiRecipesPost(
 		@Parameter(description = "", required = true) @Valid @RequestBody recipeRequest: RecipeRequest,
-	): ResponseEntity<Unit> = ResponseEntity(HttpStatus.NOT_IMPLEMENTED)
+	): ResponseEntity<List<Recipe>> = ResponseEntity(HttpStatus.NOT_IMPLEMENTED)
 
 	companion object {
 		// for your own safety never directly reuse these path definitions in tests

--- a/services/spring-api/src/main/kotlin/org/openapitools/api/AIApiController.kt
+++ b/services/spring-api/src/main/kotlin/org/openapitools/api/AIApiController.kt
@@ -1,89 +1,98 @@
 package org.openapitools.api
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import io.swagger.v3.oas.annotations.*
 import io.swagger.v3.oas.annotations.enums.*
 import io.swagger.v3.oas.annotations.media.*
 import io.swagger.v3.oas.annotations.responses.*
 import io.swagger.v3.oas.annotations.security.*
 import jakarta.validation.Valid
-import jakarta.validation.constraints.DecimalMax
-import jakarta.validation.constraints.DecimalMin
-import jakarta.validation.constraints.Email
-import jakarta.validation.constraints.Max
-import jakarta.validation.constraints.Min
-import jakarta.validation.constraints.NotNull
-import jakarta.validation.constraints.Pattern
-import jakarta.validation.constraints.Size
+import org.openapitools.entity.UserEntity
 import org.openapitools.model.HelpRequest
 import org.openapitools.model.HelpResponse
+import org.openapitools.model.RecipeInput
 import org.openapitools.model.RecipeRequest
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.http.HttpStatus
+import org.openapitools.model.UserPreferences
+import org.openapitools.model.UserProfile
+import org.openapitools.repository.UserRepository
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.security.core.userdetails.UserDetails
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.*
-import org.springframework.web.context.request.NativeWebRequest
 import org.springframework.web.reactive.function.client.WebClient
-import kotlin.collections.List
-import kotlin.collections.Map
 
 @RestController
 @Validated
 @RequestMapping("\${api.base-path:/api/v1}")
 class AIApiController(
-	private val aiWebClient: WebClient,
+	private val aiHelpWebClient: WebClient,
+	private val aiRecipeWebClient: WebClient,
+	private val userRepository: UserRepository,
+	private val objectMapper: ObjectMapper,
 ) {
 	@Operation(
 		summary = "Ask AI cooking assistant for help",
 		operationId = "aiHelpPost",
-		description = """""",
-		responses = [
-			ApiResponse(responseCode = "200", description = "AI response"),
-		],
+		responses = [ApiResponse(responseCode = "200", description = "AI response")],
+		security = [SecurityRequirement(name = "bearerAuth")],
 	)
-	@RequestMapping(
-		method = [RequestMethod.POST],
-		// "/ai/help"
-		value = [PATH_AI_HELP_POST],
-		consumes = ["application/json"],
-	)
+	@RequestMapping(method = [RequestMethod.POST], value = [PATH_AI_HELP_POST], consumes = ["application/json"])
 	fun aiHelpPost(
 		@Parameter(description = "", required = true) @Valid @RequestBody helpRequest: HelpRequest,
+		@AuthenticationPrincipal principal: UserDetails,
 	): HelpResponse {
-		val response =
-			aiWebClient
-				.post()
-				.uri(PATH_AI_HELP_POST)
-				.contentType(MediaType.APPLICATION_JSON)
-				.bodyValue(mapOf("prompt" to helpRequest.prompt))
-				.retrieve()
-				.bodyToMono(HelpResponse::class.java)
-				.block()
-		return response ?: HelpResponse("No response from AI")
+		val user = userRepository.findByUsername(principal.username).orElseThrow()
+		return aiHelpWebClient
+			.post()
+			.uri(PATH_AI_HELP_POST)
+			.contentType(MediaType.APPLICATION_JSON)
+			.bodyValue(mapOf("profile" to user.toProfile(), "recipe" to helpRequest.recipe, "prompt" to helpRequest.prompt))
+			.retrieve()
+			.bodyToMono(HelpResponse::class.java)
+			.block() ?: HelpResponse("No response from AI")
 	}
 
 	@Operation(
 		summary = "Generate recipes using AI",
 		operationId = "aiRecipesPost",
-		description = """""",
-		responses = [
-			ApiResponse(responseCode = "200", description = "Generated recipes"),
-		],
-		security = [ SecurityRequirement(name = "bearerAuth") ],
+		responses = [ApiResponse(responseCode = "200", description = "Generated recipes")],
+		security = [SecurityRequirement(name = "bearerAuth")],
 	)
-	@RequestMapping(
-		method = [RequestMethod.POST],
-		// "/ai/recipes"
-		value = [PATH_AI_RECIPES_POST],
-		consumes = ["application/json"],
-	)
+	@RequestMapping(method = [RequestMethod.POST], value = [PATH_AI_RECIPES_POST], consumes = ["application/json"])
 	fun aiRecipesPost(
 		@Parameter(description = "", required = true) @Valid @RequestBody recipeRequest: RecipeRequest,
-	): ResponseEntity<Unit> = ResponseEntity(HttpStatus.NOT_IMPLEMENTED)
+		@AuthenticationPrincipal principal: UserDetails,
+	): ResponseEntity<RecipeInput> {
+		val user = userRepository.findByUsername(principal.username).orElseThrow()
+		val response =
+			aiRecipeWebClient
+				.post()
+				.uri("/ai/recipes")
+				.contentType(MediaType.APPLICATION_JSON)
+				.bodyValue(mapOf("profile" to user.toProfile(), "prompt" to recipeRequest.prompt))
+				.retrieve()
+				.bodyToMono(RecipeInput::class.java)
+				.block() ?: return ResponseEntity.internalServerError().build()
+		return ResponseEntity.ok(response)
+	}
+
+	// Converts the DB user entity into the API UserProfile model, injecting real profile data.
+	// Password is intentionally excluded — never forwarded to the AI service.
+	private fun UserEntity.toProfile(): UserProfile {
+		val prefs =
+			preferences?.let {
+				try {
+					objectMapper.readValue(it, UserPreferences::class.java)
+				} catch (_: Exception) {
+					null
+				}
+			} ?: UserPreferences()
+		return UserProfile(username = username, preferences = prefs)
+	}
 
 	companion object {
-		// for your own safety never directly reuse these path definitions in tests
 		const val BASE_PATH: String = "/api/v1"
 		const val PATH_AI_HELP_POST: String = "/ai/help"
 		const val PATH_AI_RECIPES_POST: String = "/ai/recipes"

--- a/services/spring-api/src/main/kotlin/org/openapitools/api/AIApiController.kt
+++ b/services/spring-api/src/main/kotlin/org/openapitools/api/AIApiController.kt
@@ -64,7 +64,7 @@ class AIApiController(
 	fun aiRecipesPost(
 		@Parameter(description = "", required = true) @Valid @RequestBody recipeRequest: RecipeRequest,
 		@AuthenticationPrincipal principal: UserDetails,
-	): ResponseEntity<RecipeInput> {
+	): ResponseEntity<List<RecipeInput>> {
 		val user = userRepository.findByUsername(principal.username).orElseThrow()
 		val response =
 			aiRecipeWebClient
@@ -75,7 +75,7 @@ class AIApiController(
 				.retrieve()
 				.bodyToMono(RecipeInput::class.java)
 				.block() ?: return ResponseEntity.internalServerError().build()
-		return ResponseEntity.ok(response)
+		return ResponseEntity.ok(listOf(response))
 	}
 
 	// Converts the DB user entity into the API UserProfile model, injecting real profile data.

--- a/services/spring-api/src/main/kotlin/org/openapitools/api/RecipesApi.kt
+++ b/services/spring-api/src/main/kotlin/org/openapitools/api/RecipesApi.kt
@@ -20,6 +20,7 @@ import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Pattern
 import jakarta.validation.constraints.Size
 import org.openapitools.model.Recipe
+import org.openapitools.model.RecipeInput
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
@@ -39,7 +40,12 @@ interface RecipesApi {
 		operationId = "recipesGet",
 		description = """""",
 		responses = [
-			ApiResponse(responseCode = "200", description = "List of recipes"),
+			ApiResponse(
+				responseCode = "200",
+				description = "List of user recipes",
+				content = [Content(array = ArraySchema(schema = Schema(implementation = Recipe::class)))],
+			),
+			ApiResponse(responseCode = "403", description = "Not logged in"),
 		],
 		security = [ SecurityRequirement(name = "bearerAuth") ],
 	)
@@ -47,8 +53,9 @@ interface RecipesApi {
 		method = [RequestMethod.GET],
 		// "/recipes"
 		value = [PATH_RECIPES_GET],
+		produces = ["application/json"],
 	)
-	fun recipesGet(): ResponseEntity<Unit> = ResponseEntity(HttpStatus.NOT_IMPLEMENTED)
+	fun recipesGet(): ResponseEntity<List<Recipe>> = ResponseEntity(HttpStatus.NOT_IMPLEMENTED)
 
 	@Operation(
 		tags = ["Recipes"],
@@ -57,6 +64,7 @@ interface RecipesApi {
 		description = """""",
 		responses = [
 			ApiResponse(responseCode = "201", description = "Recipe saved"),
+			ApiResponse(responseCode = "403", description = "Not logged in"),
 		],
 		security = [ SecurityRequirement(name = "bearerAuth") ],
 	)
@@ -67,7 +75,7 @@ interface RecipesApi {
 		consumes = ["application/json"],
 	)
 	fun recipesPost(
-		@Parameter(description = "", required = true) @Valid @RequestBody recipe: Recipe,
+		@Parameter(description = "", required = true) @Valid @RequestBody recipeInput: RecipeInput,
 	): ResponseEntity<Unit> = ResponseEntity(HttpStatus.NOT_IMPLEMENTED)
 
 	@Operation(
@@ -76,7 +84,12 @@ interface RecipesApi {
 		operationId = "recipesRecipeIdGet",
 		description = """""",
 		responses = [
-			ApiResponse(responseCode = "200", description = "Recipe details"),
+			ApiResponse(
+				responseCode = "200",
+				description = "Recipe details",
+				content = [Content(schema = Schema(implementation = Recipe::class))],
+			),
+			ApiResponse(responseCode = "403", description = "Not logged in"),
 		],
 		security = [ SecurityRequirement(name = "bearerAuth") ],
 	)
@@ -84,10 +97,11 @@ interface RecipesApi {
 		method = [RequestMethod.GET],
 		// "/recipes/{recipeId}"
 		value = [PATH_RECIPES_RECIPE_ID_GET],
+		produces = ["application/json"],
 	)
 	fun recipesRecipeIdGet(
 		@Parameter(description = "", required = true) @PathVariable("recipeId") recipeId: kotlin.String,
-	): ResponseEntity<Unit> = ResponseEntity(HttpStatus.NOT_IMPLEMENTED)
+	): ResponseEntity<Recipe> = ResponseEntity(HttpStatus.NOT_IMPLEMENTED)
 
 	companion object {
 		// for your own safety never directly reuse these path definitions in tests

--- a/services/spring-api/src/main/kotlin/org/openapitools/api/RecipesApiController.kt
+++ b/services/spring-api/src/main/kotlin/org/openapitools/api/RecipesApiController.kt
@@ -1,89 +1,108 @@
 package org.openapitools.api
 
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.ObjectMapper
 import io.swagger.v3.oas.annotations.*
 import io.swagger.v3.oas.annotations.enums.*
 import io.swagger.v3.oas.annotations.media.*
 import io.swagger.v3.oas.annotations.responses.*
 import io.swagger.v3.oas.annotations.security.*
 import jakarta.validation.Valid
-import jakarta.validation.constraints.DecimalMax
-import jakarta.validation.constraints.DecimalMin
-import jakarta.validation.constraints.Email
-import jakarta.validation.constraints.Max
-import jakarta.validation.constraints.Min
-import jakarta.validation.constraints.NotNull
-import jakarta.validation.constraints.Pattern
-import jakarta.validation.constraints.Size
+import org.openapitools.entity.RecipeEntity
 import org.openapitools.model.Recipe
-import org.springframework.beans.factory.annotation.Autowired
+import org.openapitools.model.RecipeIngredient
+import org.openapitools.model.RecipeNutrients
+import org.openapitools.repository.RecipeRepository
+import org.openapitools.repository.UserRepository
 import org.springframework.http.HttpStatus
-import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.security.core.userdetails.UserDetails
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.*
-import org.springframework.web.context.request.NativeWebRequest
-import kotlin.collections.List
-import kotlin.collections.Map
 
 @RestController
 @Validated
 @RequestMapping("\${api.base-path:/api/v1}")
-class RecipesApiController {
+class RecipesApiController(
+	private val recipeRepository: RecipeRepository,
+	private val userRepository: UserRepository,
+	private val objectMapper: ObjectMapper,
+) {
+
 	@Operation(
 		summary = "List user recipes",
 		operationId = "recipesGet",
-		description = """""",
-		responses = [
-			ApiResponse(responseCode = "200", description = "List of recipes"),
-		],
-		security = [ SecurityRequirement(name = "bearerAuth") ],
+		responses = [ApiResponse(responseCode = "200", description = "List of recipes")],
+		security = [SecurityRequirement(name = "bearerAuth")],
 	)
-	@RequestMapping(
-		method = [RequestMethod.GET],
-		// "/recipes"
-		value = [PATH_RECIPES_GET],
-	)
-	fun recipesGet(): ResponseEntity<Unit> = ResponseEntity(HttpStatus.NOT_IMPLEMENTED)
+	@RequestMapping(method = [RequestMethod.GET], value = [PATH_RECIPES_GET])
+	fun recipesGet(
+		@AuthenticationPrincipal principal: UserDetails,
+	): ResponseEntity<List<Recipe>> {
+		val user = userRepository.findByUsername(principal.username).orElseThrow()
+		val recipes = recipeRepository.findByUserId(user.id).map { it.toApiModel() }
+		return ResponseEntity.ok(recipes)
+	}
 
 	@Operation(
 		summary = "Save a recipe",
 		operationId = "recipesPost",
-		description = """""",
-		responses = [
-			ApiResponse(responseCode = "201", description = "Recipe saved"),
-		],
-		security = [ SecurityRequirement(name = "bearerAuth") ],
+		responses = [ApiResponse(responseCode = "201", description = "Recipe saved")],
+		security = [SecurityRequirement(name = "bearerAuth")],
 	)
-	@RequestMapping(
-		method = [RequestMethod.POST],
-		// "/recipes"
-		value = [PATH_RECIPES_POST],
-		consumes = ["application/json"],
-	)
+	@RequestMapping(method = [RequestMethod.POST], value = [PATH_RECIPES_POST], consumes = ["application/json"])
 	fun recipesPost(
 		@Parameter(description = "", required = true) @Valid @RequestBody recipe: Recipe,
-	): ResponseEntity<Unit> = ResponseEntity(HttpStatus.NOT_IMPLEMENTED)
+		@AuthenticationPrincipal principal: UserDetails,
+	): ResponseEntity<Unit> {
+		val user = userRepository.findByUsername(principal.username).orElseThrow()
+		recipeRepository.save(
+			RecipeEntity(
+				title = recipe.title,
+				ingredients = objectMapper.writeValueAsString(recipe.ingredients),
+				instructions = objectMapper.writeValueAsString(recipe.instructions),
+				portions = recipe.portions,
+				nutrientKcal = recipe.nutrients?.calories ?: 0,
+				nutrientCarb = recipe.nutrients?.carbs ?: 0,
+				nutrientProt = recipe.nutrients?.protein ?: 0,
+				nutrientFat = recipe.nutrients?.fat ?: 0,
+				user = user,
+			),
+		)
+		return ResponseEntity(HttpStatus.CREATED)
+	}
 
 	@Operation(
 		summary = "Get recipe by ID",
 		operationId = "recipesRecipeIdGet",
-		description = """""",
-		responses = [
-			ApiResponse(responseCode = "200", description = "Recipe details"),
-		],
-		security = [ SecurityRequirement(name = "bearerAuth") ],
+		responses = [ApiResponse(responseCode = "200", description = "Recipe details")],
+		security = [SecurityRequirement(name = "bearerAuth")],
 	)
-	@RequestMapping(
-		method = [RequestMethod.GET],
-		// "/recipes/{recipeId}"
-		value = [PATH_RECIPES_RECIPE_ID_GET],
-	)
+	@RequestMapping(method = [RequestMethod.GET], value = [PATH_RECIPES_RECIPE_ID_GET])
 	fun recipesRecipeIdGet(
-		@Parameter(description = "", required = true) @PathVariable("recipeId") recipeId: kotlin.String,
-	): ResponseEntity<Unit> = ResponseEntity(HttpStatus.NOT_IMPLEMENTED)
+		@Parameter(description = "", required = true) @PathVariable("recipeId") recipeId: String,
+	): ResponseEntity<Recipe> {
+		val id = recipeId.toLongOrNull() ?: return ResponseEntity(HttpStatus.BAD_REQUEST)
+		val entity = recipeRepository.findById(id).orElse(null) ?: return ResponseEntity(HttpStatus.NOT_FOUND)
+		return ResponseEntity.ok(entity.toApiModel())
+	}
+
+	private fun RecipeEntity.toApiModel() = Recipe(
+		id = id.toInt(),
+		title = title,
+		ingredients = objectMapper.readValue(ingredients, object : TypeReference<List<RecipeIngredient>>() {}),
+		instructions = objectMapper.readValue(instructions, object : TypeReference<List<String>>() {}),
+		portions = portions,
+		nutrients = RecipeNutrients(
+			calories = nutrientKcal,
+			carbs = nutrientCarb,
+			protein = nutrientProt,
+			fat = nutrientFat,
+		),
+	)
 
 	companion object {
-		// for your own safety never directly reuse these path definitions in tests
 		const val BASE_PATH: String = "/api/v1"
 		const val PATH_RECIPES_GET: String = "/recipes"
 		const val PATH_RECIPES_POST: String = "/recipes"

--- a/services/spring-api/src/main/kotlin/org/openapitools/api/RecipesApiController.kt
+++ b/services/spring-api/src/main/kotlin/org/openapitools/api/RecipesApiController.kt
@@ -11,6 +11,7 @@ import jakarta.validation.Valid
 import org.openapitools.entity.RecipeEntity
 import org.openapitools.model.Recipe
 import org.openapitools.model.RecipeIngredient
+import org.openapitools.model.RecipeInput
 import org.openapitools.model.RecipeNutrients
 import org.openapitools.repository.RecipeRepository
 import org.openapitools.repository.UserRepository
@@ -29,7 +30,6 @@ class RecipesApiController(
 	private val userRepository: UserRepository,
 	private val objectMapper: ObjectMapper,
 ) {
-
 	@Operation(
 		summary = "List user recipes",
 		operationId = "recipesGet",
@@ -53,7 +53,7 @@ class RecipesApiController(
 	)
 	@RequestMapping(method = [RequestMethod.POST], value = [PATH_RECIPES_POST], consumes = ["application/json"])
 	fun recipesPost(
-		@Parameter(description = "", required = true) @Valid @RequestBody recipe: Recipe,
+		@Parameter(description = "", required = true) @Valid @RequestBody recipe: RecipeInput,
 		@AuthenticationPrincipal principal: UserDetails,
 	): ResponseEntity<Unit> {
 		val user = userRepository.findByUsername(principal.username).orElseThrow()
@@ -81,26 +81,31 @@ class RecipesApiController(
 	)
 	@RequestMapping(method = [RequestMethod.GET], value = [PATH_RECIPES_RECIPE_ID_GET])
 	fun recipesRecipeIdGet(
+		@AuthenticationPrincipal principal: UserDetails,
 		@Parameter(description = "", required = true) @PathVariable("recipeId") recipeId: String,
 	): ResponseEntity<Recipe> {
 		val id = recipeId.toLongOrNull() ?: return ResponseEntity(HttpStatus.BAD_REQUEST)
 		val entity = recipeRepository.findById(id).orElse(null) ?: return ResponseEntity(HttpStatus.NOT_FOUND)
+		val user = userRepository.findByUsername(principal.username).orElseThrow()
+		if (entity.user.id != user.id) return ResponseEntity(HttpStatus.FORBIDDEN)
 		return ResponseEntity.ok(entity.toApiModel())
 	}
 
-	private fun RecipeEntity.toApiModel() = Recipe(
-		id = id.toInt(),
-		title = title,
-		ingredients = objectMapper.readValue(ingredients, object : TypeReference<List<RecipeIngredient>>() {}),
-		instructions = objectMapper.readValue(instructions, object : TypeReference<List<String>>() {}),
-		portions = portions,
-		nutrients = RecipeNutrients(
-			calories = nutrientKcal,
-			carbs = nutrientCarb,
-			protein = nutrientProt,
-			fat = nutrientFat,
-		),
-	)
+	private fun RecipeEntity.toApiModel() =
+		Recipe(
+			id = id.toInt(),
+			title = title,
+			ingredients = objectMapper.readValue(ingredients, object : TypeReference<List<RecipeIngredient>>() {}),
+			instructions = objectMapper.readValue(instructions, object : TypeReference<List<String>>() {}),
+			portions = portions,
+			nutrients =
+				RecipeNutrients(
+					calories = nutrientKcal,
+					carbs = nutrientCarb,
+					protein = nutrientProt,
+					fat = nutrientFat,
+				),
+		)
 
 	companion object {
 		const val BASE_PATH: String = "/api/v1"

--- a/services/spring-api/src/main/kotlin/org/openapitools/api/UsersApi.kt
+++ b/services/spring-api/src/main/kotlin/org/openapitools/api/UsersApi.kt
@@ -22,6 +22,7 @@ import jakarta.validation.constraints.Size
 import org.openapitools.model.LoginRequest
 import org.openapitools.model.RegisterRequest
 import org.openapitools.model.UserProfile
+import org.openapitools.model.UserProfileUpdate
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
@@ -42,6 +43,7 @@ interface UsersApi {
 		description = """""",
 		responses = [
 			ApiResponse(responseCode = "200", description = "JWT token returned"),
+			ApiResponse(responseCode = "401", description = "Invalid username or password"),
 		],
 	)
 	@RequestMapping(
@@ -82,6 +84,7 @@ interface UsersApi {
 				description = "User profile and preferences",
 				content = [Content(schema = Schema(implementation = UserProfile::class))],
 			),
+			ApiResponse(responseCode = "403", description = "Not logged in"),
 		],
 		security = [ SecurityRequirement(name = "bearerAuth") ],
 	)
@@ -100,6 +103,12 @@ interface UsersApi {
 		description = """""",
 		responses = [
 			ApiResponse(responseCode = "200", description = "Profile and preferences updated"),
+			ApiResponse(
+				responseCode = "400",
+				description = "Invalid request body (e.g. empty password, username with invalid chars, unknown fields)",
+			),
+			ApiResponse(responseCode = "403", description = "Not logged in"),
+			ApiResponse(responseCode = "409", description = "Username already taken"),
 		],
 		security = [ SecurityRequirement(name = "bearerAuth") ],
 	)
@@ -110,7 +119,7 @@ interface UsersApi {
 		consumes = ["application/json"],
 	)
 	fun usersProfilePut(
-		@Parameter(description = "", required = true) @Valid @RequestBody userProfile: UserProfile,
+		@Parameter(description = "", required = true) @Valid @RequestBody userProfileUpdate: UserProfileUpdate,
 	): ResponseEntity<Unit> = ResponseEntity(HttpStatus.NOT_IMPLEMENTED)
 
 	@Operation(

--- a/services/spring-api/src/main/kotlin/org/openapitools/api/UsersApiController.kt
+++ b/services/spring-api/src/main/kotlin/org/openapitools/api/UsersApiController.kt
@@ -1,74 +1,97 @@
 package org.openapitools.api
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import io.swagger.v3.oas.annotations.*
 import io.swagger.v3.oas.annotations.enums.*
 import io.swagger.v3.oas.annotations.media.*
 import io.swagger.v3.oas.annotations.responses.*
 import io.swagger.v3.oas.annotations.security.*
 import jakarta.validation.Valid
-import jakarta.validation.constraints.DecimalMax
-import jakarta.validation.constraints.DecimalMin
-import jakarta.validation.constraints.Email
-import jakarta.validation.constraints.Max
-import jakarta.validation.constraints.Min
-import jakarta.validation.constraints.NotNull
-import jakarta.validation.constraints.Pattern
-import jakarta.validation.constraints.Size
+import org.openapitools.entity.UserEntity
 import org.openapitools.model.LoginRequest
 import org.openapitools.model.RegisterRequest
+import org.openapitools.model.UserPreferences
 import org.openapitools.model.UserProfile
-import org.springframework.beans.factory.annotation.Autowired
+import org.openapitools.model.UserProfileUpdate
+import org.openapitools.repository.UserRepository
+import org.openapitools.security.JwtUtils
 import org.springframework.http.HttpStatus
-import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
+import org.springframework.security.authentication.AuthenticationManager
+import org.springframework.security.authentication.BadCredentialsException
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.security.core.userdetails.UserDetails
+import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.*
-import org.springframework.web.context.request.NativeWebRequest
-import kotlin.collections.List
-import kotlin.collections.Map
 
 @RestController
 @Validated
 @RequestMapping("\${api.base-path:/api/v1}")
-class UsersApiController {
+class UsersApiController(
+	private val userRepository: UserRepository,
+	private val passwordEncoder: PasswordEncoder,
+	private val authManager: AuthenticationManager,
+	private val jwtUtils: JwtUtils,
+	private val objectMapper: ObjectMapper,
+) {
+	@Operation(
+		summary = "Register a new user",
+		operationId = "usersRegisterPost",
+		responses = [ApiResponse(responseCode = "201", description = "User created")],
+	)
+	@RequestMapping(method = [RequestMethod.POST], value = [PATH_USERS_REGISTER_POST], consumes = ["application/json"])
+	fun usersRegisterPost(
+		@Parameter(description = "", required = true) @Valid @RequestBody registerRequest: RegisterRequest,
+	): ResponseEntity<Unit> {
+		if (userRepository.existsByUsername(registerRequest.username)) {
+			return ResponseEntity(HttpStatus.CONFLICT)
+		}
+		userRepository.save(
+			UserEntity(
+				username = registerRequest.username,
+				password = passwordEncoder.encode(registerRequest.password)!!,
+				preferences = objectMapper.writeValueAsString(UserPreferences()),
+			),
+		)
+		return ResponseEntity(HttpStatus.CREATED)
+	}
+
 	@Operation(
 		summary = "Login user and return JWT token",
 		operationId = "usersLoginPost",
-		description = """""",
-		responses = [
-			ApiResponse(responseCode = "200", description = "JWT token returned"),
-		],
+		responses = [ApiResponse(responseCode = "200", description = "JWT token returned")],
 	)
-	@RequestMapping(
-		method = [RequestMethod.POST],
-		// "/users/login"
-		value = [PATH_USERS_LOGIN_POST],
-		consumes = ["application/json"],
-	)
+	@RequestMapping(method = [RequestMethod.POST], value = [PATH_USERS_LOGIN_POST], consumes = ["application/json"])
 	fun usersLoginPost(
 		@Parameter(description = "", required = true) @Valid @RequestBody loginRequest: LoginRequest,
-	): ResponseEntity<Unit> = ResponseEntity(HttpStatus.NOT_IMPLEMENTED)
+	): ResponseEntity<Map<String, String>> =
+		try {
+			val auth =
+				authManager.authenticate(
+					UsernamePasswordAuthenticationToken(loginRequest.username, loginRequest.password),
+				)
+			ResponseEntity.ok(mapOf("token" to jwtUtils.generateToken(auth.name)))
+		} catch (e: BadCredentialsException) {
+			ResponseEntity(HttpStatus.UNAUTHORIZED)
+		}
 
 	@Operation(
 		summary = "Logout user and invalidate token",
 		operationId = "usersLogoutPost",
-		description = """""",
-		responses = [
-			ApiResponse(responseCode = "200", description = "Logged out"),
-		],
-		security = [ SecurityRequirement(name = "bearerAuth") ],
+		responses = [ApiResponse(responseCode = "200", description = "Logged out")],
+		security = [SecurityRequirement(name = "bearerAuth")],
 	)
-	@RequestMapping(
-		method = [RequestMethod.POST],
-		// "/users/logout"
-		value = [PATH_USERS_LOGOUT_POST],
-	)
-	fun usersLogoutPost(): ResponseEntity<Unit> = ResponseEntity(HttpStatus.NOT_IMPLEMENTED)
+	@RequestMapping(method = [RequestMethod.POST], value = [PATH_USERS_LOGOUT_POST])
+	fun usersLogoutPost(): ResponseEntity<Unit> =
+		// JWTs are stateless — the client simply discards the token.
+		// For true server-side invalidation you'd need a token blocklist (e.g. Redis).
+		ResponseEntity(HttpStatus.OK)
 
 	@Operation(
 		summary = "Get current user profile and preferences",
 		operationId = "usersProfileGet",
-		description = """""",
 		responses = [
 			ApiResponse(
 				responseCode = "200",
@@ -76,55 +99,42 @@ class UsersApiController {
 				content = [Content(schema = Schema(implementation = UserProfile::class))],
 			),
 		],
-		security = [ SecurityRequirement(name = "bearerAuth") ],
+		security = [SecurityRequirement(name = "bearerAuth")],
 	)
-	@RequestMapping(
-		method = [RequestMethod.GET],
-		// "/users/profile"
-		value = [PATH_USERS_PROFILE_GET],
-		produces = ["application/json"],
-	)
-	fun usersProfileGet(): ResponseEntity<UserProfile> = ResponseEntity(HttpStatus.NOT_IMPLEMENTED)
+	@RequestMapping(method = [RequestMethod.GET], value = [PATH_USERS_PROFILE_GET], produces = ["application/json"])
+	fun usersProfileGet(
+		@AuthenticationPrincipal principal: UserDetails,
+	): ResponseEntity<UserProfile> {
+		val user = userRepository.findByUsername(principal.username).orElseThrow()
+		val prefs =
+			user.preferences?.let {
+				objectMapper.readValue(it, UserPreferences::class.java)
+			} ?: UserPreferences()
+		return ResponseEntity.ok(
+			UserProfile(username = user.username, preferences = prefs),
+		)
+	}
 
 	@Operation(
 		summary = "Update user profile and preferences",
 		operationId = "usersProfilePut",
-		description = """""",
-		responses = [
-			ApiResponse(responseCode = "200", description = "Profile and preferences updated"),
-		],
-		security = [ SecurityRequirement(name = "bearerAuth") ],
+		responses = [ApiResponse(responseCode = "200", description = "Profile and preferences updated")],
+		security = [SecurityRequirement(name = "bearerAuth")],
 	)
-	@RequestMapping(
-		method = [RequestMethod.PUT],
-		// "/users/profile"
-		value = [PATH_USERS_PROFILE_PUT],
-		consumes = ["application/json"],
-	)
+	@RequestMapping(method = [RequestMethod.PUT], value = [PATH_USERS_PROFILE_PUT], consumes = ["application/json"])
 	fun usersProfilePut(
-		@Parameter(description = "", required = true) @Valid @RequestBody userProfile: UserProfile,
-	): ResponseEntity<Unit> = ResponseEntity(HttpStatus.NOT_IMPLEMENTED)
-
-	@Operation(
-		summary = "Register a new user",
-		operationId = "usersRegisterPost",
-		description = """""",
-		responses = [
-			ApiResponse(responseCode = "201", description = "User created"),
-		],
-	)
-	@RequestMapping(
-		method = [RequestMethod.POST],
-		// "/users/register"
-		value = [PATH_USERS_REGISTER_POST],
-		consumes = ["application/json"],
-	)
-	fun usersRegisterPost(
-		@Parameter(description = "", required = true) @Valid @RequestBody registerRequest: RegisterRequest,
-	): ResponseEntity<Unit> = ResponseEntity(HttpStatus.NOT_IMPLEMENTED)
+		@Parameter(description = "", required = true) @Valid @RequestBody userProfile: UserProfileUpdate,
+		@AuthenticationPrincipal principal: UserDetails,
+	): ResponseEntity<Unit> {
+		val user = userRepository.findByUsername(principal.username).orElseThrow()
+		userProfile.preferences?.let { user.preferences = objectMapper.writeValueAsString(it) }
+		userProfile.username?.let { user.username = it }
+		userProfile.password?.let { user.password = passwordEncoder.encode(it)!! }
+		userRepository.save(user)
+		return ResponseEntity(HttpStatus.OK)
+	}
 
 	companion object {
-		// for your own safety never directly reuse these path definitions in tests
 		const val BASE_PATH: String = "/api/v1"
 		const val PATH_USERS_LOGIN_POST: String = "/users/login"
 		const val PATH_USERS_LOGOUT_POST: String = "/users/logout"

--- a/services/spring-api/src/main/kotlin/org/openapitools/api/UsersApiController.kt
+++ b/services/spring-api/src/main/kotlin/org/openapitools/api/UsersApiController.kt
@@ -128,7 +128,12 @@ class UsersApiController(
 	): ResponseEntity<Unit> {
 		val user = userRepository.findByUsername(principal.username).orElseThrow()
 		userProfile.preferences?.let { user.preferences = objectMapper.writeValueAsString(it) }
-		userProfile.username?.let { user.username = it }
+		userProfile.username?.let { newUsername ->
+			if (newUsername != user.username && userRepository.existsByUsername(newUsername)) {
+				return ResponseEntity(HttpStatus.CONFLICT)
+			}
+			user.username = newUsername
+		}
 		userProfile.password?.let { user.password = passwordEncoder.encode(it)!! }
 		userRepository.save(user)
 		return ResponseEntity(HttpStatus.OK)

--- a/services/spring-api/src/main/kotlin/org/openapitools/config/AiConfig.kt
+++ b/services/spring-api/src/main/kotlin/org/openapitools/config/AiConfig.kt
@@ -11,11 +11,28 @@ import java.time.Duration
 
 @Configuration
 class AiConfig {
-	@Value("\${ai.help.service.url:http://localhost:8081}")
-	private lateinit var aiServiceUrl: String
+	@Value("\${ai.recipe.service.url:http://localhost:8090}")
+	private lateinit var aiRecipeServiceUrl: String
+
+	@Value("\${ai.help.service.url:http://localhost:8091}")
+	private lateinit var aiHelpServiceUrl: String
 
 	@Bean
-	fun aiWebClient(): WebClient {
+	fun aiRecipeWebClient(): WebClient {
+		val pool =
+			ConnectionProvider
+				.builder("recipe")
+				.maxIdleTime(Duration.ofSeconds(2))
+				.build()
+		return WebClient
+			.builder()
+			.baseUrl(aiRecipeServiceUrl)
+			.clientConnector(ReactorClientHttpConnector(HttpClient.create(pool)))
+			.build()
+	}
+
+	@Bean
+	fun aiHelpWebClient(): WebClient {
 		val pool =
 			ConnectionProvider
 				.builder("ai")
@@ -26,7 +43,7 @@ class AiConfig {
 				.build()
 		return WebClient
 			.builder()
-			.baseUrl(aiServiceUrl)
+			.baseUrl(aiHelpServiceUrl)
 			.clientConnector(ReactorClientHttpConnector(HttpClient.create(pool)))
 			.build()
 	}

--- a/services/spring-api/src/main/kotlin/org/openapitools/config/JacksonConfig.kt
+++ b/services/spring-api/src/main/kotlin/org/openapitools/config/JacksonConfig.kt
@@ -1,0 +1,12 @@
+package org.openapitools.config
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class JacksonConfig {
+	// Spring Boot 4 no longer auto-registers ObjectMapper as a bean, so we do it explicitly.
+	@Bean
+	fun objectMapper(): ObjectMapper = ObjectMapper()
+}

--- a/services/spring-api/src/main/kotlin/org/openapitools/entity/RecipeEntity.kt
+++ b/services/spring-api/src/main/kotlin/org/openapitools/entity/RecipeEntity.kt
@@ -1,0 +1,30 @@
+package org.openapitools.entity
+
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "recipes")
+class RecipeEntity(
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	val id: Long = 0,
+
+	@Column(nullable = false)
+	var title: String,
+
+	@Column(columnDefinition = "TEXT", nullable = false)
+	var ingredients: String, // JSON array string, e.g. ["flour","eggs","milk"]
+
+	@Column(columnDefinition = "TEXT", nullable = false)
+	var instructions: String,
+
+	var portions: Int,
+	var nutrientKcal: Int,
+	var nutrientCarb: Int,
+	var nutrientProt: Int,
+	var nutrientFat: Int,
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
+	val user: UserEntity,
+)

--- a/services/spring-api/src/main/kotlin/org/openapitools/entity/UserEntity.kt
+++ b/services/spring-api/src/main/kotlin/org/openapitools/entity/UserEntity.kt
@@ -1,0 +1,19 @@
+package org.openapitools.entity
+
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "users")
+class UserEntity(
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	val id: Long = 0,
+	@Column(unique = true, nullable = false)
+	var username: String,
+	@Column(nullable = false)
+	var password: String, // always stored as a BCrypt hash
+	@Column(columnDefinition = "TEXT")
+	var preferences: String? = null, // stored as a JSON string
+	@OneToMany(mappedBy = "user", cascade = [CascadeType.ALL], orphanRemoval = true)
+	val recipes: MutableList<RecipeEntity> = mutableListOf(),
+)

--- a/services/spring-api/src/main/kotlin/org/openapitools/model/HelpRequest.kt
+++ b/services/spring-api/src/main/kotlin/org/openapitools/model/HelpRequest.kt
@@ -11,18 +11,18 @@ import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Pattern
 import jakarta.validation.constraints.Size
-import org.openapitools.model.Recipe
+import org.openapitools.model.RecipeInput
 import java.util.Objects
 
 /**
  *
- * @param prompt
  * @param recipe
+ * @param prompt
  */
 data class HelpRequest(
+	@field:Valid
+	@Schema(example = "null", required = true, description = "")
+	@get:JsonProperty("recipe", required = true) val recipe: RecipeInput,
 	@Schema(example = "null", required = true, description = "")
 	@get:JsonProperty("prompt", required = true) val prompt: kotlin.String,
-	@field:Valid
-	@Schema(example = "null", description = "")
-	@get:JsonProperty("recipe") val recipe: Recipe? = null,
 )

--- a/services/spring-api/src/main/kotlin/org/openapitools/model/HelpRequestForwarded.kt
+++ b/services/spring-api/src/main/kotlin/org/openapitools/model/HelpRequestForwarded.kt
@@ -11,13 +11,23 @@ import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Pattern
 import jakarta.validation.constraints.Size
+import org.openapitools.model.RecipeInput
+import org.openapitools.model.UserProfile
 import java.util.Objects
 
 /**
  *
+ * @param profile
+ * @param recipe
  * @param prompt
  */
-data class RecipeRequest(
+data class HelpRequestForwarded(
+	@field:Valid
+	@Schema(example = "null", required = true, description = "")
+	@get:JsonProperty("profile", required = true) val profile: UserProfile,
+	@field:Valid
+	@Schema(example = "null", required = true, description = "")
+	@get:JsonProperty("recipe", required = true) val recipe: RecipeInput,
 	@Schema(example = "null", required = true, description = "")
 	@get:JsonProperty("prompt", required = true) val prompt: kotlin.String,
 )

--- a/services/spring-api/src/main/kotlin/org/openapitools/model/Recipe.kt
+++ b/services/spring-api/src/main/kotlin/org/openapitools/model/Recipe.kt
@@ -17,16 +17,14 @@ import java.util.Objects
 
 /**
  *
- * @param id
  * @param title
  * @param ingredients
  * @param instructions
  * @param portions
+ * @param id
  * @param nutrients
  */
 data class Recipe(
-	@Schema(example = "null", required = true, description = "")
-	@get:JsonProperty("id", required = true) val id: kotlin.Int,
 	@Schema(example = "null", required = true, description = "")
 	@get:JsonProperty("title", required = true) val title: kotlin.String,
 	@field:Valid
@@ -36,6 +34,8 @@ data class Recipe(
 	@get:JsonProperty("instructions", required = true) val instructions: kotlin.collections.List<kotlin.String>,
 	@Schema(example = "null", required = true, description = "")
 	@get:JsonProperty("portions", required = true) val portions: kotlin.Int,
+	@Schema(example = "null", required = true, description = "")
+	@get:JsonProperty("id", required = true) val id: kotlin.Int,
 	@field:Valid
 	@Schema(example = "null", description = "")
 	@get:JsonProperty("nutrients") val nutrients: RecipeNutrients? = null,

--- a/services/spring-api/src/main/kotlin/org/openapitools/model/RecipeIngredient.kt
+++ b/services/spring-api/src/main/kotlin/org/openapitools/model/RecipeIngredient.kt
@@ -15,9 +15,15 @@ import java.util.Objects
 
 /**
  *
- * @param prompt
+ * @param quantity
+ * @param unit
+ * @param name
  */
-data class RecipeRequest(
-	@Schema(example = "null", required = true, description = "")
-	@get:JsonProperty("prompt", required = true) val prompt: kotlin.String,
+data class RecipeIngredient(
+	@Schema(example = "null", description = "")
+	@get:JsonProperty("quantity") val quantity: java.math.BigDecimal? = null,
+	@Schema(example = "null", description = "")
+	@get:JsonProperty("unit") val unit: kotlin.String? = null,
+	@Schema(example = "null", description = "")
+	@get:JsonProperty("name") val name: kotlin.String? = null,
 )

--- a/services/spring-api/src/main/kotlin/org/openapitools/model/RecipeIngredientsInner.kt
+++ b/services/spring-api/src/main/kotlin/org/openapitools/model/RecipeIngredientsInner.kt
@@ -15,9 +15,15 @@ import java.util.Objects
 
 /**
  *
- * @param prompt
+ * @param quantity
+ * @param unit
+ * @param name
  */
-data class RecipeRequest(
-	@Schema(example = "null", required = true, description = "")
-	@get:JsonProperty("prompt", required = true) val prompt: kotlin.String,
+data class RecipeIngredientsInner(
+	@Schema(example = "null", description = "")
+	@get:JsonProperty("quantity") val quantity: java.math.BigDecimal? = null,
+	@Schema(example = "null", description = "")
+	@get:JsonProperty("unit") val unit: kotlin.String? = null,
+	@Schema(example = "null", description = "")
+	@get:JsonProperty("name") val name: kotlin.String? = null,
 )

--- a/services/spring-api/src/main/kotlin/org/openapitools/model/RecipeInput.kt
+++ b/services/spring-api/src/main/kotlin/org/openapitools/model/RecipeInput.kt
@@ -17,16 +17,13 @@ import java.util.Objects
 
 /**
  *
- * @param id
  * @param title
  * @param ingredients
  * @param instructions
  * @param portions
  * @param nutrients
  */
-data class Recipe(
-	@Schema(example = "null", required = true, description = "")
-	@get:JsonProperty("id", required = true) val id: kotlin.Int,
+data class RecipeInput(
 	@Schema(example = "null", required = true, description = "")
 	@get:JsonProperty("title", required = true) val title: kotlin.String,
 	@field:Valid

--- a/services/spring-api/src/main/kotlin/org/openapitools/model/RecipeRequestForwarded.kt
+++ b/services/spring-api/src/main/kotlin/org/openapitools/model/RecipeRequestForwarded.kt
@@ -11,13 +11,18 @@ import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Pattern
 import jakarta.validation.constraints.Size
+import org.openapitools.model.UserProfile
 import java.util.Objects
 
 /**
  *
+ * @param profile
  * @param prompt
  */
-data class RecipeRequest(
+data class RecipeRequestForwarded(
+	@field:Valid
+	@Schema(example = "null", required = true, description = "")
+	@get:JsonProperty("profile", required = true) val profile: UserProfile,
 	@Schema(example = "null", required = true, description = "")
 	@get:JsonProperty("prompt", required = true) val prompt: kotlin.String,
 )

--- a/services/spring-api/src/main/kotlin/org/openapitools/model/UserPreferences.kt
+++ b/services/spring-api/src/main/kotlin/org/openapitools/model/UserPreferences.kt
@@ -15,9 +15,15 @@ import java.util.Objects
 
 /**
  *
- * @param prompt
+ * @param diet
+ * @param allergies
+ * @param aboutMe
  */
-data class RecipeRequest(
-	@Schema(example = "null", required = true, description = "")
-	@get:JsonProperty("prompt", required = true) val prompt: kotlin.String,
+data class UserPreferences(
+	@Schema(example = "null", description = "")
+	@get:JsonProperty("diet") val diet: kotlin.String? = null,
+	@Schema(example = "null", description = "")
+	@get:JsonProperty("allergies") val allergies: kotlin.collections.List<kotlin.String>? = null,
+	@Schema(example = "null", description = "")
+	@get:JsonProperty("aboutMe") val aboutMe: kotlin.collections.List<kotlin.String>? = null,
 )

--- a/services/spring-api/src/main/kotlin/org/openapitools/model/UserProfile.kt
+++ b/services/spring-api/src/main/kotlin/org/openapitools/model/UserProfile.kt
@@ -11,24 +11,18 @@ import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Pattern
 import jakarta.validation.constraints.Size
-import org.openapitools.model.UserProfilePreferences
+import org.openapitools.model.UserPreferences
 import java.util.Objects
 
 /**
  *
- * @param id
  * @param username
- * @param password
  * @param preferences
  */
 data class UserProfile(
 	@Schema(example = "null", required = true, description = "")
-	@get:JsonProperty("id", required = true) val id: kotlin.String,
-	@Schema(example = "null", description = "")
-	@get:JsonProperty("username") val username: kotlin.String? = null,
-	@Schema(example = "null", description = "")
-	@get:JsonProperty("password") val password: kotlin.String? = null,
+	@get:JsonProperty("username", required = true) val username: kotlin.String,
 	@field:Valid
-	@Schema(example = "null", description = "")
-	@get:JsonProperty("preferences") val preferences: UserProfilePreferences? = null,
+	@Schema(example = "null", required = true, description = "")
+	@get:JsonProperty("preferences", required = true) val preferences: UserPreferences,
 )

--- a/services/spring-api/src/main/kotlin/org/openapitools/model/UserProfilePreferences.kt
+++ b/services/spring-api/src/main/kotlin/org/openapitools/model/UserProfilePreferences.kt
@@ -17,7 +17,7 @@ import java.util.Objects
  *
  * @param diet
  * @param allergies
- * @param cuisinePreferences
+ * @param aboutMe
  */
 data class UserProfilePreferences(
 	@Schema(example = "null", description = "")
@@ -25,5 +25,5 @@ data class UserProfilePreferences(
 	@Schema(example = "null", description = "")
 	@get:JsonProperty("allergies") val allergies: kotlin.collections.List<kotlin.String>? = null,
 	@Schema(example = "null", description = "")
-	@get:JsonProperty("cuisinePreferences") val cuisinePreferences: kotlin.collections.List<kotlin.String>? = null,
+	@get:JsonProperty("aboutMe") val aboutMe: kotlin.collections.List<kotlin.String>? = null,
 )

--- a/services/spring-api/src/main/kotlin/org/openapitools/model/UserProfileUpdate.kt
+++ b/services/spring-api/src/main/kotlin/org/openapitools/model/UserProfileUpdate.kt
@@ -11,13 +11,21 @@ import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Pattern
 import jakarta.validation.constraints.Size
+import org.openapitools.model.UserPreferences
 import java.util.Objects
 
 /**
  *
- * @param prompt
+ * @param username
+ * @param password
+ * @param preferences
  */
-data class RecipeRequest(
-	@Schema(example = "null", required = true, description = "")
-	@get:JsonProperty("prompt", required = true) val prompt: kotlin.String,
+data class UserProfileUpdate(
+	@Schema(example = "null", description = "")
+	@get:JsonProperty("username") val username: kotlin.String? = null,
+	@Schema(example = "null", description = "")
+	@get:JsonProperty("password") val password: kotlin.String? = null,
+	@field:Valid
+	@Schema(example = "null", description = "")
+	@get:JsonProperty("preferences") val preferences: UserPreferences? = null,
 )

--- a/services/spring-api/src/main/kotlin/org/openapitools/repository/RecipeRepository.kt
+++ b/services/spring-api/src/main/kotlin/org/openapitools/repository/RecipeRepository.kt
@@ -1,0 +1,9 @@
+package org.openapitools.repository
+
+import org.openapitools.entity.RecipeEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface RecipeRepository : JpaRepository<RecipeEntity, Long> {
+	// Spring generates: SELECT * FROM recipes WHERE user_id = ?
+	fun findByUserId(userId: Long): List<RecipeEntity>
+}

--- a/services/spring-api/src/main/kotlin/org/openapitools/repository/UserRepository.kt
+++ b/services/spring-api/src/main/kotlin/org/openapitools/repository/UserRepository.kt
@@ -1,0 +1,11 @@
+package org.openapitools.repository
+
+import org.openapitools.entity.UserEntity
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.Optional
+
+interface UserRepository : JpaRepository<UserEntity, Long> {
+	// Spring generates: SELECT * FROM users WHERE username = ?
+	fun findByUsername(username: String): Optional<UserEntity>
+	fun existsByUsername(username: String): Boolean
+}

--- a/services/spring-api/src/main/kotlin/org/openapitools/security/JwtAuthFilter.kt
+++ b/services/spring-api/src/main/kotlin/org/openapitools/security/JwtAuthFilter.kt
@@ -1,0 +1,36 @@
+package org.openapitools.security
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.core.userdetails.UserDetailsService
+import org.springframework.web.filter.OncePerRequestFilter
+
+// Runs on every incoming request and checks the Authorization header for a valid JWT.
+// If valid, it marks the request as authenticated so Spring Security lets it through.
+class JwtAuthFilter(
+	private val jwtUtils: JwtUtils,
+	private val userDetailsService: UserDetailsService,
+) : OncePerRequestFilter() {
+
+	override fun doFilterInternal(
+		request: HttpServletRequest,
+		response: HttpServletResponse,
+		filterChain: FilterChain,
+	) {
+		// Expects: Authorization: Bearer <token>
+		val header = request.getHeader("Authorization")
+		if (header != null && header.startsWith("Bearer ")) {
+			val token = header.removePrefix("Bearer ")
+			if (jwtUtils.validateToken(token)) {
+				val username = jwtUtils.getUsernameFromToken(token)
+				val userDetails = userDetailsService.loadUserByUsername(username)
+				val auth = UsernamePasswordAuthenticationToken(userDetails, null, userDetails.authorities)
+				SecurityContextHolder.getContext().authentication = auth
+			}
+		}
+		filterChain.doFilter(request, response)
+	}
+}

--- a/services/spring-api/src/main/kotlin/org/openapitools/security/JwtUtils.kt
+++ b/services/spring-api/src/main/kotlin/org/openapitools/security/JwtUtils.kt
@@ -1,0 +1,40 @@
+package org.openapitools.security
+
+import io.jsonwebtoken.JwtException
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.security.Keys
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import java.util.Date
+
+@Component
+class JwtUtils {
+
+	@Value("\${app.jwt.secret}")
+	private lateinit var jwtSecret: String
+
+	@Value("\${app.jwt.expiration-ms}")
+	private var jwtExpirationMs: Long = 0
+
+	private fun key() = Keys.hmacShaKeyFor(jwtSecret.toByteArray())
+
+	fun generateToken(username: String): String =
+		Jwts.builder()
+			.subject(username)
+			.issuedAt(Date())
+			.expiration(Date(System.currentTimeMillis() + jwtExpirationMs))
+			.signWith(key())
+			.compact()
+
+	fun getUsernameFromToken(token: String): String =
+		Jwts.parser().verifyWith(key()).build()
+			.parseSignedClaims(token).payload.subject
+
+	fun validateToken(token: String): Boolean =
+		try {
+			Jwts.parser().verifyWith(key()).build().parseSignedClaims(token)
+			true
+		} catch (e: JwtException) {
+			false
+		}
+}

--- a/services/spring-api/src/main/kotlin/org/openapitools/security/SecurityConfig.kt
+++ b/services/spring-api/src/main/kotlin/org/openapitools/security/SecurityConfig.kt
@@ -1,0 +1,67 @@
+package org.openapitools.security
+
+import org.openapitools.repository.UserRepository
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.authentication.AuthenticationManager
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.core.userdetails.User
+import org.springframework.security.core.userdetails.UserDetailsService
+import org.springframework.security.core.userdetails.UsernameNotFoundException
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
+
+@Configuration
+class SecurityConfig(
+	private val userRepository: UserRepository,
+	private val jwtUtils: JwtUtils,
+) {
+
+	// BCrypt is the standard algorithm for hashing passwords
+	@Bean
+	fun passwordEncoder(): PasswordEncoder = BCryptPasswordEncoder()
+
+	// Tells Spring how to load a user by username — called during login to verify credentials
+	@Bean
+	fun userDetailsService(): UserDetailsService = UserDetailsService { username ->
+		val user = userRepository.findByUsername(username)
+			.orElseThrow { UsernameNotFoundException("User not found: $username") }
+		User.withUsername(user.username)
+			.password(user.password)
+			.roles("USER")
+			.build()
+	}
+
+	// The AuthenticationManager is what processes a login attempt (username + password check)
+	@Bean
+	fun authenticationManager(config: AuthenticationConfiguration): AuthenticationManager =
+		config.authenticationManager
+
+	@Bean
+	fun filterChain(http: HttpSecurity): SecurityFilterChain {
+		http
+			.csrf { it.disable() } // not needed for stateless JWT APIs
+			.sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
+			.authorizeHttpRequests { auth ->
+				auth
+					.requestMatchers(
+						"/api/v1/users/register",
+						"/api/v1/users/login",
+						"/h2-console/**",
+						"/swagger-ui/**",
+						"/v3/api-docs/**",
+					).permitAll()
+					.anyRequest().authenticated() // all other routes require a valid JWT
+			}
+			.headers { it.frameOptions { fo -> fo.disable() } } // needed for H2 console iframe
+			.addFilterBefore(
+				JwtAuthFilter(jwtUtils, userDetailsService()),
+				UsernamePasswordAuthenticationFilter::class.java,
+			)
+		return http.build()
+	}
+}

--- a/services/spring-api/src/main/resources/application.yaml
+++ b/services/spring-api/src/main/resources/application.yaml
@@ -1,6 +1,34 @@
 spring:
   application:
     name: cookingAssistant
+  datasource:
+    # Locally defaults to H2 in-memory. On GCP Cloud Run, set DB_URL (e.g. jdbc:postgresql:///<db>?socketFactory=...&cloudSqlInstance=...), DB_USER, DB_PASSWORD env vars
+    url: ${DB_URL:jdbc:h2:mem:cookingdb;DB_CLOSE_DELAY=-1}
+    username: ${DB_USER:sa}
+    password: ${DB_PASSWORD:}
+  jpa:
+    hibernate:
+      # create-drop: wipe and recreate tables every restart
+      # update: keep data between restarts
+      ddl-auto: ${JPA_DDL_AUTO:create-drop}
+    show-sql: false
+    open-in-view: false
+  h2:
+    console:
+      enabled: false # http://localhost:8080/h2-console
 
 server:
   port: 8080
+
+ai:
+  help:
+    service:
+      url: ${AI_HELP_SERVICE_URL:http://localhost:8091}
+  recipe:
+    service:
+      url: ${AI_RECIPE_SERVICE_URL:http://localhost:8090}
+
+app:
+  jwt:
+    secret: ${JWT_SECRET:local-dev-secret-change-this-in-production-use-env-var}
+    expiration-ms: 86400000   # 24 hours

--- a/services/spring-api/src/main/resources/openapi.yaml
+++ b/services/spring-api/src/main/resources/openapi.yaml
@@ -240,26 +240,11 @@ components:
       - title
     RecipeRequest:
       example:
-        profile:
-          password: password
-          preferences:
-            allergies:
-            - allergies
-            - allergies
-            cuisinePreferences:
-            - cuisinePreferences
-            - cuisinePreferences
-            diet: diet
-          id: id
-          username: username
         prompt: prompt
       properties:
-        profile:
-          $ref: "#/components/schemas/UserProfile"
         prompt:
           type: string
       required:
-      - profile
       - prompt
     HelpRequest:
       example:

--- a/web-client/src/api.ts
+++ b/web-client/src/api.ts
@@ -72,6 +72,13 @@ export interface paths {
                     };
                     content?: never;
                 };
+                /** @description Invalid username or password */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
             };
         };
         delete?: never;
@@ -140,6 +147,13 @@ export interface paths {
                         "application/json": components["schemas"]["UserProfile"];
                     };
                 };
+                /** @description Not logged in */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
             };
         };
         /** Update user profile and preferences */
@@ -152,12 +166,33 @@ export interface paths {
             };
             requestBody: {
                 content: {
-                    "application/json": components["schemas"]["UserProfile"];
+                    "application/json": components["schemas"]["UserProfileUpdate"];
                 };
             };
             responses: {
                 /** @description Profile and preferences updated */
                 200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Invalid request body (e.g. empty password, username with invalid chars, unknown fields) */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Not logged in */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Username already taken */
+                409: {
                     headers: {
                         [name: string]: unknown;
                     };
@@ -189,8 +224,17 @@ export interface paths {
             };
             requestBody?: never;
             responses: {
-                /** @description List of recipes */
+                /** @description List of user recipes */
                 200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Recipe"][];
+                    };
+                };
+                /** @description Not logged in */
+                403: {
                     headers: {
                         [name: string]: unknown;
                     };
@@ -209,12 +253,19 @@ export interface paths {
             };
             requestBody: {
                 content: {
-                    "application/json": components["schemas"]["Recipe"];
+                    "application/json": components["schemas"]["RecipeInput"];
                 };
             };
             responses: {
                 /** @description Recipe saved */
                 201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Not logged in */
+                403: {
                     headers: {
                         [name: string]: unknown;
                     };
@@ -249,6 +300,15 @@ export interface paths {
             responses: {
                 /** @description Recipe details */
                 200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Recipe"];
+                    };
+                };
+                /** @description Not logged in */
+                403: {
                     headers: {
                         [name: string]: unknown;
                     };
@@ -289,6 +349,15 @@ export interface paths {
             responses: {
                 /** @description Generated recipes */
                 200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Recipe"][];
+                    };
+                };
+                /** @description Not logged in */
+                403: {
                     headers: {
                         [name: string]: unknown;
                     };
@@ -334,6 +403,13 @@ export interface paths {
                         "application/json": components["schemas"]["HelpResponse"];
                     };
                 };
+                /** @description Not logged in */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
             };
         };
         delete?: never;
@@ -355,33 +431,59 @@ export interface components {
             password: string;
         };
         UserProfile: {
-            id: string;
+            username: string;
+            preferences: components["schemas"]["UserPreferences"];
+        };
+        UserProfileUpdate: {
             username?: string;
             password?: string;
-            preferences?: {
-                diet?: string;
-                allergies?: string[];
-                cuisinePreferences?: string[];
-            };
+            preferences?: components["schemas"]["UserPreferences"];
+        };
+        UserPreferences: {
+            diet?: string;
+            allergies?: string[];
+            aboutMe?: string[];
+        };
+        RecipeIngredient: {
+            quantity?: number;
+            unit?: string;
+            name?: string;
+        };
+        RecipeNutrients: {
+            calories?: number;
+            protein?: number;
+            fat?: number;
+            carbs?: number;
+        };
+        RecipeInput: {
+            title: string;
+            ingredients: components["schemas"]["RecipeIngredient"][];
+            instructions: string[];
+            portions: number;
+            nutrients?: components["schemas"]["RecipeNutrients"];
         };
         Recipe: {
+            id: number;
             title: string;
-            ingredients: string[];
-            instructions: string;
+            ingredients: components["schemas"]["RecipeIngredient"][];
+            instructions: string[];
             portions: number;
-            nutrients: {
-                calories?: number;
-                protein?: number;
-                fat?: number;
-                carbs?: number;
-            };
+            nutrients?: components["schemas"]["RecipeNutrients"];
         };
         RecipeRequest: {
+            prompt: string;
+        };
+        RecipeRequestForwarded: {
             profile: components["schemas"]["UserProfile"];
             prompt: string;
         };
         HelpRequest: {
-            recipe?: components["schemas"]["Recipe"];
+            recipe: components["schemas"]["RecipeInput"];
+            prompt: string;
+        };
+        HelpRequestForwarded: {
+            profile: components["schemas"]["UserProfile"];
+            recipe: components["schemas"]["RecipeInput"];
             prompt: string;
         };
         HelpResponse: {

--- a/web-client/src/api.ts
+++ b/web-client/src/api.ts
@@ -462,13 +462,8 @@ export interface components {
             portions: number;
             nutrients?: components["schemas"]["RecipeNutrients"];
         };
-        Recipe: {
+        Recipe: components["schemas"]["RecipeInput"] & {
             id: number;
-            title: string;
-            ingredients: components["schemas"]["RecipeIngredient"][];
-            instructions: string[];
-            portions: number;
-            nutrients?: components["schemas"]["RecipeNutrients"];
         };
         RecipeRequest: {
             prompt: string;


### PR DESCRIPTION
- can register on /users/register, then login on /users/login
- send /ai/recipes requests with just a prompt, user info is included by server (with jwt token as bearer in headers)
- db generates basic preferences on register so that python service doesn't 500
closes #9 closes #18