### PR TITLE
chore(web-client): run as Vite dev server under compose watch

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,18 +32,25 @@ services:
           path: ./services/spring-api/build.gradle.kts
 
   web-client:
-    build: ./web-client
+    build:
+      context: ./web-client
+      target: dev
     ports:
       - "8080:8080"
+    environment:
+      VITE_API_PROXY: http://spring-api:8080
     depends_on:
       - spring-api
     develop:
       watch:
-        - action: rebuild
+        - action: sync
           path: ./web-client/src
-        - action: rebuild
+          target: /app/src
+        - action: sync
           path: ./web-client/index.html
-        - action: rebuild
+          target: /app/index.html
+        - action: sync+restart
           path: ./web-client/vite.config.ts
+          target: /app/vite.config.ts
         - action: rebuild
           path: ./web-client/package.json

--- a/web-client/Dockerfile
+++ b/web-client/Dockerfile
@@ -6,6 +6,15 @@ RUN npm ci
 COPY . .
 RUN npm run build
 
+# --- Dev stage (Vite dev server with Hot Reload) ---
+FROM node:24-alpine AS dev
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY . .
+EXPOSE 8080
+CMD ["npm", "run", "dev", "--", "--host", "--port", "8080"]
+
 # --- Run stage ---
 FROM nginx:alpine
 COPY --from=builder /app/dist /usr/share/nginx/html

--- a/web-client/vite.config.ts
+++ b/web-client/vite.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
 		// mappings when running in dev mode
     proxy: {
       '/api': {
-        target: 'http://localhost:8080',
+        target: process.env.VITE_API_PROXY ?? 'http://localhost:8080',
         configure: (proxy) => {
           proxy.on('proxyReq', (proxyReq) => {
             // Spring's CorsConfig only allows the GitHub Pages origin; strip


### PR DESCRIPTION
## What

Makes `docker compose watch` hot-reload the web client in the browser instead of doing a full image rebuild on every source change.

## Changes

- **`web-client/Dockerfile`** — new `dev` stage running the Vite dev server (`npm run dev -- --host --port 8080`). The `builder` → nginx run stage is unchanged and remains the default, so `docker build ./web-client` (CI/K8s) still produces the prod nginx image.
- **`docker-compose.yml`** — `web-client` now builds `target: dev`; `src`/`index.html` watches switched from `rebuild` to `action: sync`


## Notes

- `docker compose up` now also runs the dev server rather than nginx — fine for local use; the prod image is built straight from the Dockerfile elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)