### PR TITLE
fix(spring-api): answer CORS preflight on protected endpoints

### DIFF
--- a/services/spring-api/src/main/kotlin/org/openapitools/config/CorsConfig.kt
+++ b/services/spring-api/src/main/kotlin/org/openapitools/config/CorsConfig.kt
@@ -1,20 +1,31 @@
 package org.openapitools.config
 
+import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.web.servlet.config.annotation.CorsRegistry
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+import org.springframework.web.cors.CorsConfiguration
+import org.springframework.web.cors.CorsConfigurationSource
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource
 
 @Configuration
-class CorsConfig : WebMvcConfigurer {
-	override fun addCorsMappings(registry: CorsRegistry) {
-		registry.addMapping("/api/**")
-			.allowedOriginPatterns(
+class CorsConfig {
+	// Exposing this as a bean (rather than via WebMvcConfigurer.addCorsMappings)
+	// lets Spring Security's CorsFilter pick it up automatically, so preflight
+	// OPTIONS requests get answered before the auth check runs.
+	@Bean
+	fun corsConfigurationSource(): CorsConfigurationSource {
+		val config = CorsConfiguration().apply {
+			allowedOriginPatterns = listOf(
 				"https://aet-devops26.github.io",
 				"http://localhost:8080",
 				"http://127.0.0.1:8080",
 				"http://0.0.0.0:8080",
 				"https://*.team-devsecops.pages.dev",
 			)
-			.allowedMethods("POST")
+			allowedMethods = listOf("GET", "POST", "PUT")
+			allowedHeaders = listOf("*")
+		}
+		return UrlBasedCorsConfigurationSource().apply {
+			registerCorsConfiguration("/api/**", config)
+		}
 	}
 }

--- a/services/spring-api/src/main/kotlin/org/openapitools/security/SecurityConfig.kt
+++ b/services/spring-api/src/main/kotlin/org/openapitools/security/SecurityConfig.kt
@@ -45,6 +45,10 @@ class SecurityConfig(
 	fun filterChain(http: HttpSecurity): SecurityFilterChain {
 		http
 			.csrf { it.disable() } // not needed for stateless JWT APIs
+			// Picks up the CorsConfigurationSource bean so preflights are answered
+			// before the auth filter — without this, OPTIONS to protected endpoints
+			// returns 403 and the browser reports a CORS error.
+			.cors { }
 			.sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
 			.authorizeHttpRequests { auth ->
 				auth


### PR DESCRIPTION
## Summary

- Preflight `OPTIONS` requests to protected endpoints (e.g. `/api/v1/ai/recipes`) were returning **403** because Spring Security ran the auth check on them. Browsers reported it as a CORS error — visible on the pages.dev previews when clicking *Generate*.
- Switch `CorsConfig` from `WebMvcConfigurer.addCorsMappings` to a `CorsConfigurationSource` bean, and add `.cors { }` to the security filter chain. Spring Security's `CorsFilter` now handles preflights before the auth filter, so OPTIONS gets a proper 200 with CORS headers and the follow-up request goes through auth as usual.
- Broaden `allowedMethods` to `GET, POST, PUT`. Only `POST` was allowed before, which would have produced the same CORS failure once `/users/profile` (GET/PUT) and `/recipes` (GET) were called from a browser.

## Test plan

- [x] Local: `OPTIONS /api/v1/ai/recipes` from `Origin: https://pr-45.team-devsecops.pages.dev` returns 200 with `Access-Control-Allow-Origin`/`-Methods`/`-Headers`.
- [x] Local: `OPTIONS /api/v1/users/profile` with `Access-Control-Request-Method: GET` returns 200 with CORS headers.
- [ ] On deploy: re-test *Generate* on the corresponding pages.dev preview after this lands on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)