### PR TITLE
Use userids in jwt tokens instead of username

### DIFF
--- a/services/spring-api/src/main/kotlin/org/openapitools/api/UsersApiController.kt
+++ b/services/spring-api/src/main/kotlin/org/openapitools/api/UsersApiController.kt
@@ -68,11 +68,11 @@ class UsersApiController(
 		@Parameter(description = "", required = true) @Valid @RequestBody loginRequest: LoginRequest,
 	): ResponseEntity<Map<String, String>> =
 		try {
-			val auth =
-				authManager.authenticate(
-					UsernamePasswordAuthenticationToken(loginRequest.username, loginRequest.password),
-				)
-			ResponseEntity.ok(mapOf("token" to jwtUtils.generateToken(auth.name)))
+			authManager.authenticate(
+				UsernamePasswordAuthenticationToken(loginRequest.username, loginRequest.password),
+			)
+			val user = userRepository.findByUsername(loginRequest.username).orElseThrow()
+			ResponseEntity.ok(mapOf("token" to jwtUtils.generateToken(user.id)))
 		} catch (e: BadCredentialsException) {
 			ResponseEntity(HttpStatus.UNAUTHORIZED)
 		}

--- a/services/spring-api/src/main/kotlin/org/openapitools/security/JwtAuthFilter.kt
+++ b/services/spring-api/src/main/kotlin/org/openapitools/security/JwtAuthFilter.kt
@@ -3,16 +3,17 @@ package org.openapitools.security
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
+import org.openapitools.repository.UserRepository
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.context.SecurityContextHolder
-import org.springframework.security.core.userdetails.UserDetailsService
+import org.springframework.security.core.userdetails.User
 import org.springframework.web.filter.OncePerRequestFilter
 
 // Runs on every incoming request and checks the Authorization header for a valid JWT.
 // If valid, it marks the request as authenticated so Spring Security lets it through.
 class JwtAuthFilter(
 	private val jwtUtils: JwtUtils,
-	private val userDetailsService: UserDetailsService,
+	private val userRepository: UserRepository,
 ) : OncePerRequestFilter() {
 
 	override fun doFilterInternal(
@@ -25,10 +26,12 @@ class JwtAuthFilter(
 		if (header != null && header.startsWith("Bearer ")) {
 			val token = header.removePrefix("Bearer ")
 			if (jwtUtils.validateToken(token)) {
-				val username = jwtUtils.getUsernameFromToken(token)
-				val userDetails = userDetailsService.loadUserByUsername(username)
-				val auth = UsernamePasswordAuthenticationToken(userDetails, null, userDetails.authorities)
-				SecurityContextHolder.getContext().authentication = auth
+				val userId = jwtUtils.getUserIdFromToken(token)
+				userRepository.findById(userId).ifPresent { entity ->
+					val userDetails = User.withUsername(entity.username).password(entity.password).roles("USER").build()
+					val auth = UsernamePasswordAuthenticationToken(userDetails, null, userDetails.authorities)
+					SecurityContextHolder.getContext().authentication = auth
+				}
 			}
 		}
 		filterChain.doFilter(request, response)

--- a/services/spring-api/src/main/kotlin/org/openapitools/security/JwtUtils.kt
+++ b/services/spring-api/src/main/kotlin/org/openapitools/security/JwtUtils.kt
@@ -18,17 +18,17 @@ class JwtUtils {
 
 	private fun key() = Keys.hmacShaKeyFor(jwtSecret.toByteArray())
 
-	fun generateToken(username: String): String =
+	fun generateToken(userId: Long): String =
 		Jwts.builder()
-			.subject(username)
+			.subject(userId.toString())
 			.issuedAt(Date())
 			.expiration(Date(System.currentTimeMillis() + jwtExpirationMs))
 			.signWith(key())
 			.compact()
 
-	fun getUsernameFromToken(token: String): String =
+	fun getUserIdFromToken(token: String): Long =
 		Jwts.parser().verifyWith(key()).build()
-			.parseSignedClaims(token).payload.subject
+			.parseSignedClaims(token).payload.subject.toLong()
 
 	fun validateToken(token: String): Boolean =
 		try {

--- a/services/spring-api/src/main/kotlin/org/openapitools/security/SecurityConfig.kt
+++ b/services/spring-api/src/main/kotlin/org/openapitools/security/SecurityConfig.kt
@@ -59,7 +59,7 @@ class SecurityConfig(
 			}
 			.headers { it.frameOptions { fo -> fo.disable() } } // needed for H2 console iframe
 			.addFilterBefore(
-				JwtAuthFilter(jwtUtils, userDetailsService()),
+				JwtAuthFilter(jwtUtils, userRepository),
 				UsernamePasswordAuthenticationFilter::class.java,
 			)
 		return http.build()


### PR DESCRIPTION
Using the username was inconvenient when changing usernames, and also a security issue.