### PR TITLE
Redirect to login page on 401/403

### DIFF
--- a/web-client/src/pages/GeneratePage.tsx
+++ b/web-client/src/pages/GeneratePage.tsx
@@ -1,19 +1,17 @@
 import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import type { components } from '../api'
-import { useAuth } from '../auth'
 import { Button } from '../components/Button'
 import { formatQuantity } from '../recipeFormat'
 import { usePressPulse } from '../usePressPulse'
 import { errorMessage } from '../apiError'
+import { SessionExpiredError, useApi } from '../useApi'
 
 type Recipe = components['schemas']['Recipe']
 type RecipeRequest = components['schemas']['RecipeRequest']
 
-const API_BASE = import.meta.env.VITE_API_BASE ?? ''
-
 export function GeneratePage() {
-  const { token } = useAuth()
+  const apiFetch = useApi()
   const navigate = useNavigate()
   const [generateBtnRef, pulseGenerate] = usePressPulse<HTMLButtonElement>()
   const [prompt, setPrompt] = useState('')
@@ -35,12 +33,9 @@ export function GeneratePage() {
     setRecipes([])
     try {
       const body: RecipeRequest = { prompt }
-      const response = await fetch(`${API_BASE}/api/v1/ai/recipes`, {
+      const response = await apiFetch('/api/v1/ai/recipes', {
         method: 'POST',
-        headers: {
-          'content-type': 'application/json',
-          authorization: `Bearer ${token}`,
-        },
+        headers: { 'content-type': 'application/json' },
         body: JSON.stringify(body),
       })
       if (!response.ok) throw new Error(await errorMessage(response, `HTTP ${response.status}`))
@@ -48,6 +43,7 @@ export function GeneratePage() {
       setRecipes(data)
       setStatus(data.length === 0 ? 'No recipes returned.' : null)
     } catch (e) {
+      if (e instanceof SessionExpiredError) return
       setStatus(`Error: ${e instanceof Error ? e.message : String(e)}`)
     } finally {
       setLoading(false)

--- a/web-client/src/pages/ProfilePage.tsx
+++ b/web-client/src/pages/ProfilePage.tsx
@@ -11,11 +11,10 @@ import { Button } from '../components/Button'
 import { PasswordInput } from '../components/PasswordInput'
 import { usePressPulse } from '../usePressPulse'
 import { errorMessage } from '../apiError'
+import { SessionExpiredError, useApi } from '../useApi'
 
 type UserProfile = components['schemas']['UserProfile']
 type UserProfileUpdate = components['schemas']['UserProfileUpdate']
-
-const API_BASE = import.meta.env.VITE_API_BASE ?? ''
 
 const allergyPlaceholders = [
   'e.g. peanuts',
@@ -36,7 +35,8 @@ const dietPlaceholders = [
 ]
 
 export function ProfilePage() {
-  const { username, token, signOut, updateUsername } = useAuth()
+  const { username, signOut, updateUsername } = useAuth()
+  const apiFetch = useApi()
   const navigate = useNavigate()
 
   const [prefsBtnRef, pulsePrefs] = usePressPulse<HTMLButtonElement>()
@@ -60,17 +60,9 @@ export function ProfilePage() {
 
 	// fetch the currently stored user profile
   useEffect(() => {
-    if (!token) return
     let cancelled = false
-    fetch(`${API_BASE}/api/v1/users/profile`, {
-      headers: { authorization: `Bearer ${token}` },
-    })
+    apiFetch('/api/v1/users/profile')
       .then(async (res) => {
-        if (res.status === 403 || res.status === 401) {
-          signOut()
-          navigate('/login')
-          return
-        }
         if (!res.ok) throw new Error(await errorMessage(res, `HTTP ${res.status}`))
         const data = (await res.json()) as UserProfile
         if (cancelled) return
@@ -80,27 +72,20 @@ export function ProfilePage() {
         setAllergies(prefs.allergies?.length ? prefs.allergies : ['', ''])
       })
       .catch((e) => {
-        if (!cancelled) setPrefsStatus({ kind: 'error', msg: e instanceof Error ? e.message : String(e) })
+        if (cancelled || e instanceof SessionExpiredError) return
+        setPrefsStatus({ kind: 'error', msg: e instanceof Error ? e.message : String(e) })
       })
     return () => {
       cancelled = true
     }
-  }, [token, signOut, navigate])
+  }, [apiFetch])
 
   async function updateProfile(body: UserProfileUpdate): Promise<void> {
-    const res = await fetch(`${API_BASE}/api/v1/users/profile`, {
+    const res = await apiFetch('/api/v1/users/profile', {
       method: 'PUT',
-      headers: {
-        'content-type': 'application/json',
-        authorization: `Bearer ${token}`,
-      },
+      headers: { 'content-type': 'application/json' },
       body: JSON.stringify(body),
     })
-    if (res.status === 403 || res.status === 401) {
-      signOut()
-      navigate('/login')
-      throw new Error('Session expired')
-    }
     if (res.status === 409) throw new Error(await errorMessage(res, 'Username already taken'))
     if (res.status === 400) throw new Error(await errorMessage(res, 'Invalid request'))
     if (!res.ok) throw new Error(await errorMessage(res, `HTTP ${res.status}`))
@@ -120,6 +105,7 @@ export function ProfilePage() {
       })
       setPrefsStatus({ kind: 'ok', msg: 'Preferences saved' })
     } catch (e) {
+      if (e instanceof SessionExpiredError) return
       setPrefsStatus({ kind: 'error', msg: e instanceof Error ? e.message : String(e) })
     } finally {
       setPrefsSaving(false)
@@ -142,6 +128,7 @@ export function ProfilePage() {
       setUsernameDraft(null)
       setUsernameStatus({ kind: 'ok', msg: 'Username updated' })
     } catch (e) {
+      if (e instanceof SessionExpiredError) return
       setUsernameStatus({ kind: 'error', msg: e instanceof Error ? e.message : String(e) })
     } finally {
       setUsernameSaving(false)
@@ -167,6 +154,7 @@ export function ProfilePage() {
       setRepeatNewPassword('')
       setPasswordStatus({ kind: 'ok', msg: 'Password updated' })
     } catch (e) {
+      if (e instanceof SessionExpiredError) return
       setPasswordStatus({ kind: 'error', msg: e instanceof Error ? e.message : String(e) })
     } finally {
       setPasswordSaving(false)

--- a/web-client/src/pages/RecipePage.tsx
+++ b/web-client/src/pages/RecipePage.tsx
@@ -10,17 +10,15 @@ import {
 import Markdown from 'react-markdown'
 import { Navigate, useLocation, useNavigate } from 'react-router-dom'
 import type { components } from '../api'
-import { useAuth } from '../auth'
 import { formatQuantity } from '../recipeFormat'
 import { usePressPulse } from '../usePressPulse'
 import { errorMessage } from '../apiError'
+import { SessionExpiredError, useApi } from '../useApi'
 
 type Recipe = components['schemas']['Recipe']
 type HelpRequest = components['schemas']['HelpRequest']
 type HelpResponse = components['schemas']['HelpResponse']
 type HelpEntry = { question: string; answer: string }
-
-const API_BASE = import.meta.env.VITE_API_BASE ?? ''
 
 function toggleSetItem(set: Set<number>, item: number): Set<number> {
   const next = new Set(set)
@@ -71,7 +69,7 @@ function RecipeView({
   onAnswer: (entry: HelpEntry) => void
 }) {
   const navigate = useNavigate()
-  const { token } = useAuth()
+  const apiFetch = useApi()
 
   const [portions, setPortions] = useState(recipe.portions)
   const [checkedIngredients, setCheckedIngredients] = useState<Set<number>>(new Set())
@@ -113,12 +111,9 @@ function RecipeView({
         },
         prompt: question,
       }
-      const response = await fetch(`${API_BASE}/api/v1/ai/help`, {
+      const response = await apiFetch('/api/v1/ai/help', {
         method: 'POST',
-        headers: {
-          'content-type': 'application/json',
-          authorization: `Bearer ${token}`,
-        },
+        headers: { 'content-type': 'application/json' },
         body: JSON.stringify(body),
       })
       if (!response.ok) throw new Error(await errorMessage(response, `HTTP ${response.status}`))
@@ -126,6 +121,7 @@ function RecipeView({
       onAnswer({ question, answer: data.response ?? 'No response.' })
       setHelpPrompt('')
     } catch (e) {
+      if (e instanceof SessionExpiredError) return
       setHelpError(`Error: ${e instanceof Error ? e.message : String(e)}`)
     } finally {
       setHelpLoading(false)

--- a/web-client/src/useApi.ts
+++ b/web-client/src/useApi.ts
@@ -1,0 +1,28 @@
+import { useCallback } from 'react'
+import { useAuth } from './auth'
+
+const API_BASE = import.meta.env.VITE_API_BASE ?? ''
+
+export class SessionExpiredError extends Error {
+  constructor() {
+    super('Session expired')
+    this.name = 'SessionExpiredError'
+  }
+}
+
+export function useApi() {
+  const { token, signOut } = useAuth()
+  return useCallback(
+    async (path: string, init: RequestInit = {}): Promise<Response> => {
+      const headers = new Headers(init.headers)
+      if (token) headers.set('authorization', `Bearer ${token}`)
+      const res = await fetch(`${API_BASE}${path}`, { ...init, headers })
+      if (res.status === 401 || res.status === 403) {
+        signOut()
+        throw new SessionExpiredError()
+      }
+      return res
+    },
+    [token, signOut],
+  )
+}


### PR DESCRIPTION
## What

Introduces a `useApi()` hook that wraps `fetch` for authenticated calls:

- adds the `Authorization: Bearer <token>` header
- centralizes 401/403 handling — signs the user out (which `RequireAuth` turns into a redirect to `/login`) and throws `SessionExpiredError` 

## Notes

- No behavior change for the happy path; purely a refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)