### PR TITLE
Frontend tests: unit (Vitest) + E2E (Playwright)

### DIFF
--- a/.github/workflows/build-client.yml
+++ b/.github/workflows/build-client.yml
@@ -31,6 +31,9 @@ jobs:
 
   build-test:
     runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      pull-requests: write
     defaults:
       run:
         working-directory: web-client
@@ -53,11 +56,27 @@ jobs:
       - name: Unit tests
         run: npm test
 
+      - name: Publish unit test results
+        uses: dorny/test-reporter@v1
+        if: always()
+        with:
+          name: Web Client Unit Tests
+          path: web-client/test-results/vitest-junit.xml
+          reporter: jest-junit
+
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
 
       - name: E2E tests
         run: npm run test:e2e
+
+      - name: Publish E2E test results
+        uses: dorny/test-reporter@v1
+        if: always()
+        with:
+          name: Web Client E2E Tests
+          path: web-client/test-results/playwright-junit.xml
+          reporter: jest-junit
 
       - name: Upload Playwright report
         if: failure()

--- a/.github/workflows/build-client.yml
+++ b/.github/workflows/build-client.yml
@@ -1,4 +1,4 @@
-name: Web Client - Lint, Build, Test
+name: Web Client - Lint & Test
 
 on:
   pull_request:
@@ -8,7 +8,7 @@ on:
     paths: ['web-client/**', '.github/workflows/build-client.yml']
 
 jobs:
-  lint-build-test:
+  lint:
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -28,6 +28,24 @@ jobs:
 
       - name: Lint
         run: npm run lint
+
+  build-test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web-client
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+          cache-dependency-path: web-client/package-lock.json
+
+      - name: Install
+        run: npm ci
 
       - name: Build
         run: npm run build

--- a/.github/workflows/build-client.yml
+++ b/.github/workflows/build-client.yml
@@ -1,14 +1,14 @@
-name: Web Client - Lint and Build
+name: Web Client - Lint, Build, Test
 
 on:
   pull_request:
-    paths: ['web-client/**', '.github/workflows/web-client-ci.yml']
+    paths: ['web-client/**', '.github/workflows/build-client.yml']
   push:
     branches: [main]
-    paths: ['web-client/**', '.github/workflows/web-client-ci.yml']
+    paths: ['web-client/**', '.github/workflows/build-client.yml']
 
 jobs:
-  lint-build:
+  lint-build-test:
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -31,3 +31,20 @@ jobs:
 
       - name: Build
         run: npm run build
+
+      - name: Unit tests
+        run: npm test
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: E2E tests
+        run: npm run test:e2e
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: web-client/playwright-report/
+          retention-days: 7

--- a/web-client/.gitignore
+++ b/web-client/.gitignore
@@ -12,6 +12,12 @@ dist
 dist-ssr
 *.local
 
+# Playwright
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/web-client/package-lock.json
+++ b/web-client/package-lock.json
@@ -17,20 +17,85 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@playwright/test": "^1.60.0",
         "@tailwindcss/vite": "^4.2.4",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/node": "^24.12.2",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.2.0",
+        "@vitest/coverage-v8": "^4.1.7",
         "eslint": "^10.2.1",
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.5.0",
+        "jsdom": "^29.1.1",
         "tailwindcss": "^4.2.4",
         "typescript": "~6.0.2",
         "typescript-eslint": "^8.58.2",
-        "vite": "^7.3.2"
+        "vite": "^7.3.2",
+        "vitest": "^4.1.7"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -266,6 +331,16 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -312,6 +387,169 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.1.tgz",
+      "integrity": "sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.4.tgz",
+      "integrity": "sha512-wgsqt92b7C7tQhIdPNxj0n9zuUbQlvAuI1exyzeNrOKOi62SD7ren8zqszmpVREjAOqg8cD2FqYhQfAuKjk4sw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -884,6 +1122,24 @@
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@heroicons/react": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.2.0.tgz",
@@ -1007,6 +1263,22 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -1366,6 +1638,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.4.tgz",
@@ -1650,6 +1929,104 @@
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1695,6 +2072,17 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -1703,6 +2091,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
@@ -2062,6 +2457,150 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.7.tgz",
+      "integrity": "sha512-qsYPeXc5Q9dFLd1i8Ap+Bx8sQgcp+rFVQo4R0dDsWNBzl26ldVF1qOO+RL24K7FDrR6pA+50XedRLSoSG24bVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.7",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.7",
+        "vitest": "4.1.7"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.7.tgz",
+      "integrity": "sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.7.tgz",
+      "integrity": "sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.7.tgz",
+      "integrity": "sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.7.tgz",
+      "integrity": "sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.7",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.7.tgz",
+      "integrity": "sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.7.tgz",
+      "integrity": "sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.7.tgz",
+      "integrity": "sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.7",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -2102,6 +2641,70 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.2.tgz",
+      "integrity": "sha512-dKmJxJsGItLmc5CYZKuEjuG6GnBs6PG4gohMhyFOWKaNQoYCuRZJDECaBlHmcG0lv2wc2E0uU8lESmBEumC3DQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/bail": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
@@ -2133,6 +2736,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/brace-expansion": {
@@ -2211,6 +2824,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/character-entities": {
@@ -2298,6 +2921,27 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -2316,6 +2960,20 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2332,6 +2990,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.3.0",
@@ -2385,6 +3050,14 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.349",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.349.tgz",
@@ -2405,6 +3078,26 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.27.7",
@@ -2653,6 +3346,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2661,6 +3364,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/extend": {
@@ -2817,6 +3530,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/hast-util-to-jsx-runtime": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
@@ -2874,6 +3597,26 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
@@ -2902,6 +3645,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/inline-style-parser": {
@@ -2989,12 +3742,58 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/jiti": {
       "version": "2.6.1",
@@ -3012,6 +3811,57 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -3381,6 +4231,17 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -3389,6 +4250,47 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/mdast-util-from-markdown": {
@@ -3543,6 +4445,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/micromark": {
       "version": "4.0.2",
@@ -3986,6 +4895,16 @@
       ],
       "license": "MIT"
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
@@ -4039,6 +4958,17 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
       "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
       "license": "MIT"
     },
     "node_modules/optionator": {
@@ -4116,6 +5046,19 @@
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
       "license": "MIT"
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -4136,6 +5079,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -4154,6 +5104,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {
@@ -4208,6 +5205,22 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
     "node_modules/property-information": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
@@ -4248,6 +5261,14 @@
       "peerDependencies": {
         "react": "^19.2.5"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -4324,6 +5345,20 @@
         "react-dom": ">=18"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/remark-parse": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
@@ -4355,6 +5390,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/rollup": {
@@ -4402,6 +5447,19 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -4447,6 +5505,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -4467,6 +5532,20 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
@@ -4479,6 +5558,19 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/style-to-js": {
@@ -4498,6 +5590,26 @@
       "dependencies": {
         "inline-style-parser": "0.2.7"
       }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwindcss": {
       "version": "4.2.4",
@@ -4519,6 +5631,23 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.2.tgz",
+      "integrity": "sha512-M/Q0B2cp4K7kynaT/vnED1j8TlLY+Pp7C6Wl2bl/7u/F0mUVwdyOpwomQb8JpYLitHUssAJRmLZdMCGsrx7i+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -4534,6 +5663,62 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.0.tgz",
+      "integrity": "sha512-yHBe+zVfzNZ3QfTPW/Z6KK1G2t340gFjMHqI/4KKSt/abzYydzuCnpqdaF5gCCABby+9Yfbj59oR5F2Fd5CBzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.0"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.1.tgz",
+      "integrity": "sha512-sc2nGvGbixlJRHwTh/qQdPXTxJU1UDJboGPQm4d/01YUJ9r/u6aeIulQvEaxUlvKDN7hb1qCLjax+jhVAPLa/g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/trim-lines": {
@@ -4626,6 +5811,16 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.26.0.tgz",
+      "integrity": "sha512-3O9Tf67pGhgOv9jM35AbhkXAKi13f3oy3aE4CSgr+TckGeY+/iu97ZXN+J7DpHPzLbVApFd1IFhcnBjREYXYcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -4872,6 +6067,144 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.7.tgz",
+      "integrity": "sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.7",
+        "@vitest/mocker": "4.1.7",
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/runner": "4.1.7",
+        "@vitest/snapshot": "4.1.7",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.7",
+        "@vitest/browser-preview": "4.1.7",
+        "@vitest/browser-webdriverio": "4.1.7",
+        "@vitest/coverage-istanbul": "4.1.7",
+        "@vitest/coverage-v8": "4.1.7",
+        "@vitest/ui": "4.1.7",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4888,6 +6221,23 @@
         "node": ">= 8"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -4897,6 +6247,23 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/web-client/package.json
+++ b/web-client/package.json
@@ -7,7 +7,10 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",
@@ -19,18 +22,25 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@playwright/test": "^1.60.0",
     "@tailwindcss/vite": "^4.2.4",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^24.12.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.2.0",
+    "@vitest/coverage-v8": "^4.1.7",
     "eslint": "^10.2.1",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.5.0",
+    "jsdom": "^29.1.1",
     "tailwindcss": "^4.2.4",
     "typescript": "~6.0.2",
     "typescript-eslint": "^8.58.2",
-    "vite": "^7.3.2"
+    "vite": "^7.3.2",
+    "vitest": "^4.1.7"
   }
 }

--- a/web-client/playwright.config.ts
+++ b/web-client/playwright.config.ts
@@ -8,7 +8,10 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  reporter: 'list',
+  reporter: [
+    ['list'],
+    ['junit', { outputFile: 'test-results/playwright-junit.xml' }],
+  ],
   use: {
     baseURL: BASE,
     trace: 'on-first-retry',

--- a/web-client/playwright.config.ts
+++ b/web-client/playwright.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig, devices } from '@playwright/test'
+
+const PORT = 4173
+const BASE = `http://127.0.0.1:${PORT}/team-devsecops/`
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  reporter: 'list',
+  use: {
+    baseURL: BASE,
+    trace: 'on-first-retry',
+  },
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+  webServer: {
+    command: `npm run dev -- --host 127.0.0.1 --port ${PORT} --strictPort`,
+    url: BASE,
+    reuseExistingServer: !process.env.CI,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  },
+})

--- a/web-client/tests/apiError.test.ts
+++ b/web-client/tests/apiError.test.ts
@@ -10,12 +10,20 @@ function jsonResponse(body: unknown): Response {
 describe('errorMessage', () => {
   it('returns the server message when present', async () => {
     const res = jsonResponse({ message: 'Username already taken' })
-    expect(await errorMessage(res, 'fallback')).toBe('Username already taken')
+
+    const message = await errorMessage(res, 'fallback')
+
+    expect(message).toBe('Username already taken')
   })
 
   it('falls back when the body is missing a message or unparseable', async () => {
-    expect(await errorMessage(jsonResponse({ message: '   ' }), 'fallback')).toBe('fallback')
+    const whitespaceMessage = jsonResponse({ message: '   ' })
     const garbage = new Response('not json', { status: 500 })
-    expect(await errorMessage(garbage, 'fallback')).toBe('fallback')
+
+    const fromWhitespace = await errorMessage(whitespaceMessage, 'fallback')
+    const fromGarbage = await errorMessage(garbage, 'fallback')
+
+    expect(fromWhitespace).toBe('fallback')
+    expect(fromGarbage).toBe('fallback')
   })
 })

--- a/web-client/tests/apiError.test.ts
+++ b/web-client/tests/apiError.test.ts
@@ -1,0 +1,21 @@
+import { errorMessage } from '../src/apiError'
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 400,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+describe('errorMessage', () => {
+  it('returns the server message when present', async () => {
+    const res = jsonResponse({ message: 'Username already taken' })
+    expect(await errorMessage(res, 'fallback')).toBe('Username already taken')
+  })
+
+  it('falls back when the body is missing a message or unparseable', async () => {
+    expect(await errorMessage(jsonResponse({ message: '   ' }), 'fallback')).toBe('fallback')
+    const garbage = new Response('not json', { status: 500 })
+    expect(await errorMessage(garbage, 'fallback')).toBe('fallback')
+  })
+})

--- a/web-client/tests/auth.test.tsx
+++ b/web-client/tests/auth.test.tsx
@@ -1,0 +1,96 @@
+import { act, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, vi } from 'vitest'
+import { AuthProvider, useAuth } from '../src/auth'
+import { jsonResponse } from './utils'
+
+const fetchMock = vi.fn<typeof fetch>()
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', fetchMock)
+})
+afterEach(() => {
+  fetchMock.mockReset()
+  vi.unstubAllGlobals()
+})
+
+function DemoSignin() {
+  const auth = useAuth()
+  return (
+    <div>
+      <span data-testid="token">{auth.token ?? ''}</span>
+      <span data-testid="username">{auth.username ?? ''}</span>
+      <button onClick={() => void auth.signIn('alice', 'pw').catch(() => {})}>signIn</button>
+      <button onClick={() => void auth.register('bob', 'pw').catch(() => {})}>register</button>
+      <button onClick={() => auth.signOut()}>signOut</button>
+    </div>
+  )
+}
+
+function setup() {
+  render(
+    <AuthProvider>
+      <DemoSignin />
+    </AuthProvider>,
+  )
+}
+
+describe('AuthProvider', () => {
+  it('persists token and username on signIn and clears them on signOut', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ token: 'tkn-1' }))
+    setup()
+
+    await act(async () => screen.getByText('signIn').click())
+    expect(screen.getByTestId('token')).toHaveTextContent('tkn-1')
+    expect(screen.getByTestId('username')).toHaveTextContent('alice')
+    expect(localStorage.getItem('auth_token')).toBe('tkn-1')
+
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 200 }))
+    await act(async () => screen.getByText('signOut').click())
+    expect(screen.getByTestId('token')).toHaveTextContent('')
+    expect(localStorage.getItem('auth_token')).toBeNull()
+  })
+
+  it('register hits /register then /login and stores the new session', async () => {
+    fetchMock
+      .mockResolvedValueOnce(new Response(null, { status: 200 })) // register
+      .mockResolvedValueOnce(jsonResponse({ token: 'tkn-2' })) // login
+    setup()
+
+    await act(async () => screen.getByText('register').click())
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(fetchMock.mock.calls[0][0]).toContain('/api/v1/users/register')
+    expect(fetchMock.mock.calls[1][0]).toContain('/api/v1/users/login')
+    expect(screen.getByTestId('token')).toHaveTextContent('tkn-2')
+    expect(screen.getByTestId('username')).toHaveTextContent('bob')
+  })
+
+  it('surfaces the server message on a 401 login', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ message: 'Invalid username or password' }, { status: 401 }),
+    )
+    let captured: unknown
+    function Catcher() {
+      const auth = useAuth()
+      return (
+        <button
+          onClick={() =>
+            auth.signIn('alice', 'pw').catch((e) => {
+              captured = e
+            })
+          }
+        >
+          go
+        </button>
+      )
+    }
+    render(
+      <AuthProvider>
+        <Catcher />
+      </AuthProvider>,
+    )
+    await act(async () => screen.getByText('go').click())
+    expect(captured).toBeInstanceOf(Error)
+    expect((captured as Error).message).toBe('Invalid username or password')
+  })
+})

--- a/web-client/tests/auth.test.tsx
+++ b/web-client/tests/auth.test.tsx
@@ -1,96 +1,107 @@
-import { act, render, screen } from '@testing-library/react'
-import { afterEach, beforeEach, vi } from 'vitest'
-import { AuthProvider, useAuth } from '../src/auth'
-import { jsonResponse } from './utils'
+import {act, render, screen} from '@testing-library/react'
+import {afterEach, beforeEach, vi} from 'vitest'
+import {AuthProvider, useAuth} from '../src/auth'
+import {jsonResponse} from './utils'
 
 const fetchMock = vi.fn<typeof fetch>()
 
 beforeEach(() => {
-  vi.stubGlobal('fetch', fetchMock)
+	vi.stubGlobal('fetch', fetchMock)
 })
 afterEach(() => {
-  fetchMock.mockReset()
-  vi.unstubAllGlobals()
+	fetchMock.mockReset()
+	vi.unstubAllGlobals()
 })
 
 function DemoSignin() {
-  const auth = useAuth()
-  return (
-    <div>
-      <span data-testid="token">{auth.token ?? ''}</span>
-      <span data-testid="username">{auth.username ?? ''}</span>
-      <button onClick={() => void auth.signIn('alice', 'pw').catch(() => {})}>signIn</button>
-      <button onClick={() => void auth.register('bob', 'pw').catch(() => {})}>register</button>
-      <button onClick={() => auth.signOut()}>signOut</button>
-    </div>
-  )
+	const auth = useAuth()
+	return (
+		<div>
+			<span data-testid="token">{auth.token ?? ''}</span>
+			<span data-testid="username">{auth.username ?? ''}</span>
+			<button onClick={() => void auth.signIn('alice', 'pw').catch(() => {
+			})}>signIn
+			</button>
+			<button onClick={() => void auth.register('bob', 'pw').catch(() => {
+			})}>register
+			</button>
+			<button onClick={() => auth.signOut()}>signOut</button>
+		</div>
+	)
 }
 
 function setup() {
-  render(
-    <AuthProvider>
-      <DemoSignin />
-    </AuthProvider>,
-  )
+	render(
+		<AuthProvider>
+			<DemoSignin/>
+		</AuthProvider>,
+	)
 }
 
 describe('AuthProvider', () => {
-  it('persists token and username on signIn and clears them on signOut', async () => {
-    fetchMock.mockResolvedValueOnce(jsonResponse({ token: 'tkn-1' }))
-    setup()
+	it('persists token and username on signIn and clears them on signOut', async () => {
+		setup()
 
-    await act(async () => screen.getByText('signIn').click())
-    expect(screen.getByTestId('token')).toHaveTextContent('tkn-1')
-    expect(screen.getByTestId('username')).toHaveTextContent('alice')
-    expect(localStorage.getItem('auth_token')).toBe('tkn-1')
+		fetchMock.mockResolvedValueOnce(jsonResponse({token: 'tkn-1'}))
+		await act(async () => screen.getByText('signIn').click())
+		expect(screen.getByTestId('token')).toHaveTextContent('tkn-1')
+		expect(screen.getByTestId('username')).toHaveTextContent('alice')
+		expect(localStorage.getItem('auth_token')).toBe('tkn-1')
 
-    fetchMock.mockResolvedValueOnce(new Response(null, { status: 200 }))
-    await act(async () => screen.getByText('signOut').click())
-    expect(screen.getByTestId('token')).toHaveTextContent('')
-    expect(localStorage.getItem('auth_token')).toBeNull()
-  })
+		fetchMock.mockResolvedValueOnce(new Response(null, {status: 200}))
+		await act(async () => screen.getByText('signOut').click())
+		expect(screen.getByTestId('token')).toHaveTextContent('')
+		expect(localStorage.getItem('auth_token')).toBeNull()
+	})
 
-  it('register hits /register then /login and stores the new session', async () => {
-    fetchMock
-      .mockResolvedValueOnce(new Response(null, { status: 200 })) // register
-      .mockResolvedValueOnce(jsonResponse({ token: 'tkn-2' })) // login
-    setup()
+	it('register hits /register then /login and stores the new session', async () => {
+		fetchMock
+			.mockResolvedValueOnce(new Response(null, {status: 200})) // register
+			.mockResolvedValueOnce(jsonResponse({token: 'tkn-2'})) // login
+		setup()
 
-    await act(async () => screen.getByText('register').click())
+		await act(async () => screen.getByText('register').click())
 
-    expect(fetchMock).toHaveBeenCalledTimes(2)
-    expect(fetchMock.mock.calls[0][0]).toContain('/api/v1/users/register')
-    expect(fetchMock.mock.calls[1][0]).toContain('/api/v1/users/login')
-    expect(screen.getByTestId('token')).toHaveTextContent('tkn-2')
-    expect(screen.getByTestId('username')).toHaveTextContent('bob')
-  })
+		expect(fetchMock).toHaveBeenCalledTimes(2)
+		expect(fetchMock.mock.calls[0][0]).toContain('/api/v1/users/register')
+		expect(fetchMock.mock.calls[1][0]).toContain('/api/v1/users/login')
+		expect(screen.getByTestId('token')).toHaveTextContent('tkn-2')
+		expect(screen.getByTestId('username')).toHaveTextContent('bob')
+	})
 
-  it('surfaces the server message on a 401 login', async () => {
-    fetchMock.mockResolvedValueOnce(
-      jsonResponse({ message: 'Invalid username or password' }, { status: 401 }),
-    )
-    let captured: unknown
-    function Catcher() {
-      const auth = useAuth()
-      return (
-        <button
-          onClick={() =>
-            auth.signIn('alice', 'pw').catch((e) => {
-              captured = e
-            })
-          }
-        >
-          go
-        </button>
-      )
-    }
-    render(
-      <AuthProvider>
-        <Catcher />
-      </AuthProvider>,
-    )
-    await act(async () => screen.getByText('go').click())
-    expect(captured).toBeInstanceOf(Error)
-    expect((captured as Error).message).toBe('Invalid username or password')
-  })
+	it('surfaces the server message on a 401 login', async () => {
+		// Arrange
+		fetchMock.mockResolvedValueOnce(
+			jsonResponse({message: 'Invalid username or password'}, {status: 401}),
+		)
+		let captured: unknown
+
+		function Catcher() {
+			const auth = useAuth()
+			return (
+				<button
+					onClick={() =>
+						auth.signIn('alice', 'pw').catch((e) => {
+							captured = e
+						})
+					}
+				>
+					go
+				</button>
+			)
+		}
+
+		render(
+			<AuthProvider>
+				<Catcher/>
+			</AuthProvider>,
+		)
+
+		// Act
+		await act(async () => screen.getByText('go').click())
+
+		// Assert
+		expect(captured).toBeInstanceOf(Error)
+		expect((captured as Error).message).toBe('Invalid username or password')
+	})
 })

--- a/web-client/tests/e2e/smoke.spec.ts
+++ b/web-client/tests/e2e/smoke.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test'
+
+const recipe = {
+  id: 1,
+  title: 'Tomato Pasta',
+  portions: 2,
+  ingredients: [{ name: 'tomato', quantity: 4, unit: '' }],
+  instructions: ['boil pasta', 'add sauce'],
+  nutrients: { calories: 500, protein: 20, fat: 10, carbs: 60 },
+}
+
+test('login -> generate -> open recipe -> log out', async ({ page }) => {
+  await page.route('**/api/v1/users/login', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ token: 'tok' }) }),
+  )
+  await page.route('**/api/v1/ai/recipes', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([recipe]) }),
+  )
+  await page.route('**/api/v1/users/logout', (route) => route.fulfill({ status: 200 }))
+  // ProfilePage runs a GET on mount; a 401 here would trigger an auto-signOut
+  // and detach the Log out button before we can click it
+  await page.route('**/api/v1/users/profile', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ username: 'demo', preferences: {} }),
+    }),
+  )
+
+  await page.goto('login')
+  await page.getByLabel('Username').fill('demo')
+  await page.getByLabel('Password', { exact: true }).first().fill('test')
+  // both the active tab and the submit button are labelled "Login"; submit via Enter
+  await page.keyboard.press('Enter')
+
+  await expect(page).toHaveURL(/\/generate$/)
+  await page.getByPlaceholder(/What do you want to cook/i).fill('pasta')
+  await page.getByRole('button', { name: 'Generate' }).click()
+
+  await page.getByRole('button', { name: /Tomato Pasta/ }).click()
+  await expect(page).toHaveURL(/\/recipe$/)
+  await expect(page.getByRole('heading', { name: 'Tomato Pasta' })).toBeVisible()
+
+  await page.goto('profile')
+  await page.getByRole('button', { name: 'Log out' }).click()
+  await expect(page).toHaveURL(/\/login$/)
+})

--- a/web-client/tests/e2e/smoke.spec.ts
+++ b/web-client/tests/e2e/smoke.spec.ts
@@ -1,47 +1,48 @@
-import { test, expect } from '@playwright/test'
+import {expect, test} from '@playwright/test'
 
 const recipe = {
-  id: 1,
-  title: 'Tomato Pasta',
-  portions: 2,
-  ingredients: [{ name: 'tomato', quantity: 4, unit: '' }],
-  instructions: ['boil pasta', 'add sauce'],
-  nutrients: { calories: 500, protein: 20, fat: 10, carbs: 60 },
+	id: 1,
+	title: 'Tomato Pasta',
+	portions: 2,
+	ingredients: [{name: 'tomato', quantity: 4, unit: 'pcs'}],
+	instructions: ['boil pasta', 'add sauce'],
+	nutrients: {calories: 500, protein: 20, fat: 10, carbs: 60},
 }
 
-test('login -> generate -> open recipe -> log out', async ({ page }) => {
-  await page.route('**/api/v1/users/login', (route) =>
-    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ token: 'tok' }) }),
-  )
-  await page.route('**/api/v1/ai/recipes', (route) =>
-    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([recipe]) }),
-  )
-  await page.route('**/api/v1/users/logout', (route) => route.fulfill({ status: 200 }))
-  // ProfilePage runs a GET on mount; a 401 here would trigger an auto-signOut
-  // and detach the Log out button before we can click it
-  await page.route('**/api/v1/users/profile', (route) =>
-    route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ username: 'demo', preferences: {} }),
-    }),
-  )
+test('login -> generate -> open recipe -> log out', async ({page}) => {
+	// Arrange
+	await page.route('**/api/v1/users/login', (route) =>
+		route.fulfill({status: 200, contentType: 'application/json', body: JSON.stringify({token: 'tok'})}),
+	)
+	await page.route('**/api/v1/ai/recipes', (route) =>
+		route.fulfill({
+			status: 200, contentType: 'application/json', body: JSON.stringify([recipe])
+		}),
+	)
+	await page.route('**/api/v1/users/logout', (route) => route.fulfill({status: 200}))
+	await page.route('**/api/v1/users/profile', (route) =>
+		route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({username: 'demo', preferences: {}}),
+		}),
+	)
 
-  await page.goto('login')
-  await page.getByLabel('Username').fill('demo')
-  await page.getByLabel('Password', { exact: true }).first().fill('test')
-  // both the active tab and the submit button are labelled "Login"; submit via Enter
-  await page.keyboard.press('Enter')
+	// Act & Assert
+	await page.goto('login')
+	await page.getByLabel('Username').fill('demo')
+	await page.getByLabel('Password', {exact: true}).first().fill('test')
+	await page.keyboard.press('Enter')
 
-  await expect(page).toHaveURL(/\/generate$/)
-  await page.getByPlaceholder(/What do you want to cook/i).fill('pasta')
-  await page.getByRole('button', { name: 'Generate' }).click()
+	await expect(page).toHaveURL(/\/generate$/)
+	await page.getByPlaceholder(/What do you want to cook/i).fill('pasta')
+	await page.getByRole('button', {name: 'Generate'}).click()
 
-  await page.getByRole('button', { name: /Tomato Pasta/ }).click()
-  await expect(page).toHaveURL(/\/recipe$/)
-  await expect(page.getByRole('heading', { name: 'Tomato Pasta' })).toBeVisible()
+	await page.getByRole('button', {name: /Tomato Pasta/}).click()
+	await expect(page).toHaveURL(/\/recipe$/)
+	await expect(page.getByRole('heading', {name: 'Tomato Pasta'})).toBeVisible()
 
-  await page.goto('profile')
-  await page.getByRole('button', { name: 'Log out' }).click()
-  await expect(page).toHaveURL(/\/login$/)
+	await page.goto('profile')
+	await page.getByRole('button', {name: 'Log out'}).click()
+	await expect(page).toHaveURL(/\/login$/)
 })

--- a/web-client/tests/pages/GeneratePage.test.tsx
+++ b/web-client/tests/pages/GeneratePage.test.tsx
@@ -12,7 +12,7 @@ const recipe: Recipe = {
   id: 1,
   title: 'Tomato Pasta',
   portions: 2,
-  ingredients: [{ name: 'tomato', quantity: 4, unit: '' }],
+  ingredients: [{ name: 'tomato', quantity: 4, unit: 'pcs' }],
   instructions: ['boil pasta', 'add sauce'],
   nutrients: { calories: 0, protein: 0, fat: 0, carbs: 0 },
 }
@@ -28,7 +28,7 @@ afterEach(() => {
 })
 
 function render() {
-  return renderWithProviders(
+  renderWithProviders(
     <Routes>
       <Route path="/generate" element={<GeneratePage />} />
     </Routes>,
@@ -39,7 +39,9 @@ function render() {
 describe('GeneratePage', () => {
   it('restores previously generated recipes from sessionStorage', () => {
     sessionStorage.setItem('generated_recipes', JSON.stringify([recipe]))
+
     render()
+
     expect(screen.getByText('Tomato Pasta')).toBeInTheDocument()
     expect(screen.getByText('2 portions')).toBeInTheDocument()
   })

--- a/web-client/tests/pages/GeneratePage.test.tsx
+++ b/web-client/tests/pages/GeneratePage.test.tsx
@@ -1,0 +1,69 @@
+import { Route, Routes } from 'react-router-dom'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, vi } from 'vitest'
+import type { components } from '../../src/api'
+import { GeneratePage } from '../../src/pages/GeneratePage'
+import { jsonResponse, renderWithProviders } from '../utils'
+
+type Recipe = components['schemas']['Recipe']
+
+const recipe: Recipe = {
+  id: 1,
+  title: 'Tomato Pasta',
+  portions: 2,
+  ingredients: [{ name: 'tomato', quantity: 4, unit: '' }],
+  instructions: ['boil pasta', 'add sauce'],
+  nutrients: { calories: 0, protein: 0, fat: 0, carbs: 0 },
+}
+
+const fetchMock = vi.fn<typeof fetch>()
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', fetchMock)
+})
+afterEach(() => {
+  fetchMock.mockReset()
+  vi.unstubAllGlobals()
+})
+
+function render() {
+  return renderWithProviders(
+    <Routes>
+      <Route path="/generate" element={<GeneratePage />} />
+    </Routes>,
+    { route: '/generate', token: { value: 'tkn', username: 'alice' } },
+  )
+}
+
+describe('GeneratePage', () => {
+  it('restores previously generated recipes from sessionStorage', () => {
+    sessionStorage.setItem('generated_recipes', JSON.stringify([recipe]))
+    render()
+    expect(screen.getByText('Tomato Pasta')).toBeInTheDocument()
+    expect(screen.getByText('2 portions')).toBeInTheDocument()
+  })
+
+  it('shows the "No recipes returned" message when the server returns an empty list', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse([]))
+    const user = userEvent.setup()
+    render()
+
+    await user.type(screen.getByPlaceholderText(/What do you want to cook/i), 'anything')
+    await user.click(screen.getByRole('button', { name: 'Generate' }))
+
+    expect(await screen.findByText('No recipes returned.')).toBeInTheDocument()
+  })
+
+  it('shows a server error and clears the loading state', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ message: 'GenAI down' }, { status: 503 }))
+    const user = userEvent.setup()
+    render()
+
+    await user.type(screen.getByPlaceholderText(/What do you want to cook/i), 'pasta')
+    await user.click(screen.getByRole('button', { name: 'Generate' }))
+
+    expect(await screen.findByText('Error: GenAI down')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Generate' })).toBeEnabled()
+  })
+})

--- a/web-client/tests/pages/LoginPage.test.tsx
+++ b/web-client/tests/pages/LoginPage.test.tsx
@@ -16,7 +16,7 @@ afterEach(() => {
 })
 
 function renderLogin(opts?: Parameters<typeof renderWithProviders>[1]) {
-  return renderWithProviders(
+  renderWithProviders(
     <Routes>
       <Route path="/login" element={<LoginPage />} />
       <Route path="/generate" element={<div>generate page</div>} />
@@ -33,6 +33,7 @@ describe('LoginPage', () => {
     await user.type(screen.getByLabelText('Username'), 'alice')
     await user.type(screen.getByLabelText('Password'), 'one')
     await user.type(screen.getByLabelText('Repeat password'), 'two')
+
     await user.click(screen.getByRole('button', { name: 'Sign up' }))
 
     expect(await screen.findByText('Passwords do not match')).toBeInTheDocument()
@@ -43,10 +44,9 @@ describe('LoginPage', () => {
     fetchMock.mockResolvedValueOnce(jsonResponse({ message: 'Nope' }, { status: 401 }))
     const user = userEvent.setup()
     renderLogin()
-
     await user.type(screen.getByLabelText('Username'), 'alice')
     await user.type(screen.getByLabelText('Password'), 'wrong')
-    // both the active tab and the submit button render "Login"; submit via Enter to disambiguate
+
     await user.keyboard('{Enter}')
 
     expect(await screen.findByText('Nope')).toBeInTheDocument()
@@ -54,6 +54,7 @@ describe('LoginPage', () => {
 
   it('redirects to /generate when already signed in', async () => {
     renderLogin({ token: { value: 'tkn', username: 'alice' } })
+
     await waitFor(() => expect(screen.getByText('generate page')).toBeInTheDocument())
   })
 })

--- a/web-client/tests/pages/LoginPage.test.tsx
+++ b/web-client/tests/pages/LoginPage.test.tsx
@@ -1,0 +1,59 @@
+import { Route, Routes } from 'react-router-dom'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, vi } from 'vitest'
+import { LoginPage } from '../../src/pages/LoginPage'
+import { jsonResponse, renderWithProviders } from '../utils'
+
+const fetchMock = vi.fn<typeof fetch>()
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', fetchMock)
+})
+afterEach(() => {
+  fetchMock.mockReset()
+  vi.unstubAllGlobals()
+})
+
+function renderLogin(opts?: Parameters<typeof renderWithProviders>[1]) {
+  return renderWithProviders(
+    <Routes>
+      <Route path="/login" element={<LoginPage />} />
+      <Route path="/generate" element={<div>generate page</div>} />
+    </Routes>,
+    { route: '/login', ...opts },
+  )
+}
+
+describe('LoginPage', () => {
+  it('blocks register submit when passwords do not match (no network call)', async () => {
+    const user = userEvent.setup()
+    renderLogin()
+    await user.click(screen.getByRole('button', { name: 'Register' }))
+    await user.type(screen.getByLabelText('Username'), 'alice')
+    await user.type(screen.getByLabelText('Password'), 'one')
+    await user.type(screen.getByLabelText('Repeat password'), 'two')
+    await user.click(screen.getByRole('button', { name: 'Sign up' }))
+
+    expect(await screen.findByText('Passwords do not match')).toBeInTheDocument()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('surfaces the server error message on a failed login', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ message: 'Nope' }, { status: 401 }))
+    const user = userEvent.setup()
+    renderLogin()
+
+    await user.type(screen.getByLabelText('Username'), 'alice')
+    await user.type(screen.getByLabelText('Password'), 'wrong')
+    // both the active tab and the submit button render "Login"; submit via Enter to disambiguate
+    await user.keyboard('{Enter}')
+
+    expect(await screen.findByText('Nope')).toBeInTheDocument()
+  })
+
+  it('redirects to /generate when already signed in', async () => {
+    renderLogin({ token: { value: 'tkn', username: 'alice' } })
+    await waitFor(() => expect(screen.getByText('generate page')).toBeInTheDocument())
+  })
+})

--- a/web-client/tests/pages/ProfilePage.test.tsx
+++ b/web-client/tests/pages/ProfilePage.test.tsx
@@ -16,7 +16,7 @@ afterEach(() => {
 })
 
 function render() {
-  return renderWithProviders(
+  renderWithProviders(
     <Routes>
       <Route path="/profile" element={<ProfilePage />} />
       <Route path="/login" element={<div>login page</div>} />
@@ -25,7 +25,6 @@ function render() {
   )
 }
 
-// the page issues a GET on mount; route any GET to a stub profile
 function defaultProfileFetch(body: { username: string }) {
   fetchMock.mockImplementation((_input, init) => {
     const method = init?.method ?? 'GET'
@@ -41,9 +40,9 @@ describe('ProfilePage', () => {
     defaultProfileFetch({ username: 'alice' })
     const user = userEvent.setup()
     render()
-
     await user.type(screen.getByLabelText('New password'), 'aaa')
     await user.type(screen.getByLabelText('Repeat new password'), 'bbb')
+
     await user.click(screen.getByRole('button', { name: 'Update password' }))
 
     expect(await screen.findByText('Passwords do not match')).toBeInTheDocument()
@@ -54,10 +53,10 @@ describe('ProfilePage', () => {
     defaultProfileFetch({ username: 'alice' })
     const user = userEvent.setup()
     render()
-
     // fill only the first allergy slot; the second stays empty
     const allergyInputs = await screen.findAllByPlaceholderText(/e\.g\. (peanuts|shellfish)/i)
     await user.type(allergyInputs[0], 'peanuts')
+
     await user.click(screen.getByRole('button', { name: 'Update taste preferences' }))
 
     await waitFor(() => {
@@ -83,10 +82,10 @@ describe('ProfilePage', () => {
     })
     const user = userEvent.setup()
     render()
-
     const usernameField = await screen.findByLabelText('New username')
     await user.clear(usernameField)
     await user.type(usernameField, 'bob')
+
     await user.click(screen.getByRole('button', { name: 'Update username' }))
 
     expect(await screen.findByText('Username already taken')).toBeInTheDocument()

--- a/web-client/tests/pages/ProfilePage.test.tsx
+++ b/web-client/tests/pages/ProfilePage.test.tsx
@@ -1,0 +1,94 @@
+import { Route, Routes } from 'react-router-dom'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, vi } from 'vitest'
+import { ProfilePage } from '../../src/pages/ProfilePage'
+import { jsonResponse, renderWithProviders } from '../utils'
+
+const fetchMock = vi.fn<typeof fetch>()
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', fetchMock)
+})
+afterEach(() => {
+  fetchMock.mockReset()
+  vi.unstubAllGlobals()
+})
+
+function render() {
+  return renderWithProviders(
+    <Routes>
+      <Route path="/profile" element={<ProfilePage />} />
+      <Route path="/login" element={<div>login page</div>} />
+    </Routes>,
+    { route: '/profile', token: { value: 'tkn', username: 'alice' } },
+  )
+}
+
+// the page issues a GET on mount; route any GET to a stub profile
+function defaultProfileFetch(body: { username: string }) {
+  fetchMock.mockImplementation((_input, init) => {
+    const method = init?.method ?? 'GET'
+    if (method === 'GET') {
+      return Promise.resolve(jsonResponse({ username: body.username, preferences: {} }))
+    }
+    return Promise.resolve(jsonResponse({}))
+  })
+}
+
+describe('ProfilePage', () => {
+  it('blocks the password update when the two fields disagree (no PUT issued)', async () => {
+    defaultProfileFetch({ username: 'alice' })
+    const user = userEvent.setup()
+    render()
+
+    await user.type(screen.getByLabelText('New password'), 'aaa')
+    await user.type(screen.getByLabelText('Repeat new password'), 'bbb')
+    await user.click(screen.getByRole('button', { name: 'Update password' }))
+
+    expect(await screen.findByText('Passwords do not match')).toBeInTheDocument()
+    expect(fetchMock.mock.calls.filter(([, init]) => init?.method === 'PUT')).toHaveLength(0)
+  })
+
+  it('strips empty diet/allergy entries before sending the preferences PUT', async () => {
+    defaultProfileFetch({ username: 'alice' })
+    const user = userEvent.setup()
+    render()
+
+    // fill only the first allergy slot; the second stays empty
+    const allergyInputs = await screen.findAllByPlaceholderText(/e\.g\. (peanuts|shellfish)/i)
+    await user.type(allergyInputs[0], 'peanuts')
+    await user.click(screen.getByRole('button', { name: 'Update taste preferences' }))
+
+    await waitFor(() => {
+      expect(
+        fetchMock.mock.calls.find(([, init]) => init?.method === 'PUT'),
+      ).toBeDefined()
+    })
+    const putCall = fetchMock.mock.calls.find(([, init]) => init?.method === 'PUT')!
+    const body = JSON.parse(putCall[1]!.body as string)
+    expect(body.preferences.allergies).toEqual(['peanuts'])
+    expect(body.preferences.diet).toEqual([])
+  })
+
+  it('shows "Username already taken" on a 409 from the username PUT', async () => {
+    fetchMock.mockImplementation((_input, init) => {
+      const method = init?.method ?? 'GET'
+      if (method === 'GET') {
+        return Promise.resolve(jsonResponse({ username: 'alice', preferences: {} }))
+      }
+      return Promise.resolve(
+        jsonResponse({ message: 'Username already taken' }, { status: 409 }),
+      )
+    })
+    const user = userEvent.setup()
+    render()
+
+    const usernameField = await screen.findByLabelText('New username')
+    await user.clear(usernameField)
+    await user.type(usernameField, 'bob')
+    await user.click(screen.getByRole('button', { name: 'Update username' }))
+
+    expect(await screen.findByText('Username already taken')).toBeInTheDocument()
+  })
+})

--- a/web-client/tests/pages/RecipePage.test.tsx
+++ b/web-client/tests/pages/RecipePage.test.tsx
@@ -1,65 +1,60 @@
-import { Route, Routes } from 'react-router-dom'
-import { screen } from '@testing-library/react'
+import {Route, Routes} from 'react-router-dom'
+import {screen} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import type { components } from '../../src/api'
-import { RecipePage } from '../../src/pages/RecipePage'
-import { renderWithProviders } from '../utils'
+import type {components} from '../../src/api'
+import {RecipePage} from '../../src/pages/RecipePage'
+import {renderWithProviders} from '../utils'
 
 type Recipe = components['schemas']['Recipe']
 
 const a: Recipe = {
-  id: 1,
-  title: 'Tomato Pasta',
-  portions: 2,
-  ingredients: [{ name: 'tomato', quantity: 4, unit: '' }],
-  instructions: ['boil pasta', 'add sauce'],
-  nutrients: { calories: 500, protein: 20, fat: 10, carbs: 60 },
+	id: 1,
+	title: 'Tomato Pasta',
+	portions: 2,
+	ingredients: [{name: 'tomato', quantity: 4, unit: 'pcs'}],
+	instructions: ['boil pasta', 'add sauce'],
+	nutrients: {calories: 500, protein: 20, fat: 10, carbs: 60},
 }
-const b: Recipe = { ...a, id: 2, title: 'Pesto Pasta' }
+const b: Recipe = {...a, id: 2, title: 'Pesto Pasta'}
 
 function render(index = 0, recipes: Recipe[] = [a, b]) {
-  sessionStorage.setItem('generated_recipes', JSON.stringify(recipes))
-  return renderWithProviders(
-    <Routes>
-      <Route path="/generate" element={<div>generate page</div>} />
-      <Route path="/recipe" element={<RecipePage />} />
-    </Routes>,
-    {
-      route: { pathname: '/recipe', state: { index } },
-      token: { value: 'tkn', username: 'alice' },
-    },
-  )
+	sessionStorage.setItem('generated_recipes', JSON.stringify(recipes))
+	renderWithProviders(
+		<Routes>
+			<Route path="/generate" element={<div>generate page</div>}/>
+			<Route path="/recipe" element={<RecipePage/>}/>
+		</Routes>,
+		{
+			route: {pathname: '/recipe', state: {index}},
+			token: {value: 'tkn', username: 'alice'},
+		},
+	)
 }
 
 describe('RecipePage', () => {
-  it('scales ingredient quantities and kcal when portions are doubled', async () => {
-    const user = userEvent.setup()
-    render(0)
+	it('scales ingredient quantities and kcal when portions are doubled', async () => {
+		const user = userEvent.setup()
+		render(0)
 
-    // baseline: 4 tomato, 500 kcal at 2 portions
-    expect(screen.getByText(/4 tomato/i)).toBeInTheDocument()
-    expect(screen.getByText('500 kcal')).toBeInTheDocument()
+		// baseline: 4 tomato, 500 kcal at 2 portions
+		expect(screen.getByText(/4 tomato/i)).toBeInTheDocument()
+		expect(screen.getByText('500 kcal')).toBeInTheDocument()
 
-    // 2 -> 4 portions (two +0.5 + one +1 step crosses the threshold; just click + repeatedly)
-    const inc = screen.getByRole('button', { name: 'Increase portions' })
-    await user.click(inc) // 2.5
-    await user.click(inc) // 3
-    await user.click(inc) // 3.5
-    await user.click(inc) // 4
+		const inc = screen.getByRole('button', {name: 'Increase portions'})
+		await user.click(inc) // 2.5
+		await user.click(inc) // 3
+		await user.click(inc) // 3.5
+		await user.click(inc) // 4
 
-    expect(screen.getByText(/8 tomato/i)).toBeInTheDocument()
-    expect(screen.getByText('1000 kcal')).toBeInTheDocument()
-  })
+		expect(screen.getByText(/8 tomato/i)).toBeInTheDocument()
+		expect(screen.getByText('1000 kcal')).toBeInTheDocument()
+	})
 
-  it('redirects to /generate when the requested recipe is missing', () => {
-    render(5)
-    expect(screen.getByText('generate page')).toBeInTheDocument()
-  })
+	it('disables Previous on the first recipe and Next on the last', () => {
+		render(0)
 
-  it('disables Previous on the first recipe and Next on the last', () => {
-    render(0)
-    // mobile prev/next is the bottom bar; assert via aria-label
-    expect(screen.getByRole('button', { name: 'Previous recipe' })).toBeDisabled()
-    expect(screen.getByRole('button', { name: 'Next recipe' })).toBeEnabled()
-  })
+		// mobile prev/next is the bottom bar; assert via aria-label
+		expect(screen.getByRole('button', {name: 'Previous recipe'})).toBeDisabled()
+		expect(screen.getByRole('button', {name: 'Next recipe'})).toBeEnabled()
+	})
 })

--- a/web-client/tests/pages/RecipePage.test.tsx
+++ b/web-client/tests/pages/RecipePage.test.tsx
@@ -1,0 +1,65 @@
+import { Route, Routes } from 'react-router-dom'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { components } from '../../src/api'
+import { RecipePage } from '../../src/pages/RecipePage'
+import { renderWithProviders } from '../utils'
+
+type Recipe = components['schemas']['Recipe']
+
+const a: Recipe = {
+  id: 1,
+  title: 'Tomato Pasta',
+  portions: 2,
+  ingredients: [{ name: 'tomato', quantity: 4, unit: '' }],
+  instructions: ['boil pasta', 'add sauce'],
+  nutrients: { calories: 500, protein: 20, fat: 10, carbs: 60 },
+}
+const b: Recipe = { ...a, id: 2, title: 'Pesto Pasta' }
+
+function render(index = 0, recipes: Recipe[] = [a, b]) {
+  sessionStorage.setItem('generated_recipes', JSON.stringify(recipes))
+  return renderWithProviders(
+    <Routes>
+      <Route path="/generate" element={<div>generate page</div>} />
+      <Route path="/recipe" element={<RecipePage />} />
+    </Routes>,
+    {
+      route: { pathname: '/recipe', state: { index } },
+      token: { value: 'tkn', username: 'alice' },
+    },
+  )
+}
+
+describe('RecipePage', () => {
+  it('scales ingredient quantities and kcal when portions are doubled', async () => {
+    const user = userEvent.setup()
+    render(0)
+
+    // baseline: 4 tomato, 500 kcal at 2 portions
+    expect(screen.getByText(/4 tomato/i)).toBeInTheDocument()
+    expect(screen.getByText('500 kcal')).toBeInTheDocument()
+
+    // 2 -> 4 portions (two +0.5 + one +1 step crosses the threshold; just click + repeatedly)
+    const inc = screen.getByRole('button', { name: 'Increase portions' })
+    await user.click(inc) // 2.5
+    await user.click(inc) // 3
+    await user.click(inc) // 3.5
+    await user.click(inc) // 4
+
+    expect(screen.getByText(/8 tomato/i)).toBeInTheDocument()
+    expect(screen.getByText('1000 kcal')).toBeInTheDocument()
+  })
+
+  it('redirects to /generate when the requested recipe is missing', () => {
+    render(5)
+    expect(screen.getByText('generate page')).toBeInTheDocument()
+  })
+
+  it('disables Previous on the first recipe and Next on the last', () => {
+    render(0)
+    // mobile prev/next is the bottom bar; assert via aria-label
+    expect(screen.getByRole('button', { name: 'Previous recipe' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Next recipe' })).toBeEnabled()
+  })
+})

--- a/web-client/tests/pages/RecipePage.test.tsx
+++ b/web-client/tests/pages/RecipePage.test.tsx
@@ -36,8 +36,8 @@ describe('RecipePage', () => {
 		const user = userEvent.setup()
 		render(0)
 
-		// baseline: 4 tomato, 500 kcal at 2 portions
-		expect(screen.getByText(/4 tomato/i)).toBeInTheDocument()
+		// baseline: 4 pcs tomato, 500 kcal at 2 portions
+		expect(screen.getByText(/4 pcs tomato/i)).toBeInTheDocument()
 		expect(screen.getByText('500 kcal')).toBeInTheDocument()
 
 		const inc = screen.getByRole('button', {name: 'Increase portions'})
@@ -46,7 +46,7 @@ describe('RecipePage', () => {
 		await user.click(inc) // 3.5
 		await user.click(inc) // 4
 
-		expect(screen.getByText(/8 tomato/i)).toBeInTheDocument()
+		expect(screen.getByText(/8 pcs tomato/i)).toBeInTheDocument()
 		expect(screen.getByText('1000 kcal')).toBeInTheDocument()
 	})
 

--- a/web-client/tests/recipeFormat.test.ts
+++ b/web-client/tests/recipeFormat.test.ts
@@ -1,14 +1,10 @@
-import { formatQuantity } from '../src/recipeFormat'
+import {formatQuantity} from '../src/recipeFormat'
 
 describe('formatQuantity', () => {
-  it('renders fractional values as glyphs and respects scaling', () => {
-    expect(formatQuantity(0.5)).toBe('½')
-    expect(formatQuantity(1.5)).toBe('1 ½')
-    expect(formatQuantity(1, 0.5)).toBe('½')
-  })
-
-  it('uses plain decimals above the glyph threshold and trims trailing zeros', () => {
-    expect(formatQuantity(6.123)).toBe('6.12')
-    expect(formatQuantity(10)).toBe('10')
-  })
+	it('renders fractional values as glyphs and respects scaling', () => {
+		expect(formatQuantity(0.5)).toBe('½')
+		expect(formatQuantity(1.5)).toBe('1 ½')
+		expect(formatQuantity(1, 0.5)).toBe('½')
+		expect(formatQuantity(6.123)).toBe('6.12')
+	})
 })

--- a/web-client/tests/recipeFormat.test.ts
+++ b/web-client/tests/recipeFormat.test.ts
@@ -1,0 +1,14 @@
+import { formatQuantity } from '../src/recipeFormat'
+
+describe('formatQuantity', () => {
+  it('renders fractional values as glyphs and respects scaling', () => {
+    expect(formatQuantity(0.5)).toBe('½')
+    expect(formatQuantity(1.5)).toBe('1 ½')
+    expect(formatQuantity(1, 0.5)).toBe('½')
+  })
+
+  it('uses plain decimals above the glyph threshold and trims trailing zeros', () => {
+    expect(formatQuantity(6.123)).toBe('6.12')
+    expect(formatQuantity(10)).toBe('10')
+  })
+})

--- a/web-client/tests/setup.ts
+++ b/web-client/tests/setup.ts
@@ -1,0 +1,9 @@
+import '@testing-library/jest-dom/vitest'
+import { afterEach } from 'vitest'
+import { cleanup } from '@testing-library/react'
+
+afterEach(() => {
+  cleanup()
+  localStorage.clear()
+  sessionStorage.clear()
+})

--- a/web-client/tests/utils.tsx
+++ b/web-client/tests/utils.tsx
@@ -1,28 +1,28 @@
-import type { ReactElement } from 'react'
-import { MemoryRouter } from 'react-router-dom'
-import type { InitialEntry } from 'react-router-dom'
-import { render } from '@testing-library/react'
-import { AuthProvider } from '../src/auth'
+import type {ReactElement} from 'react'
+import type {InitialEntry} from 'react-router-dom'
+import {MemoryRouter} from 'react-router-dom'
+import {render} from '@testing-library/react'
+import {AuthProvider} from '../src/auth'
 
 export function renderWithProviders(
-  ui: ReactElement,
-  { route = '/', token }: { route?: InitialEntry; token?: { value: string; username: string } } = {},
+	ui: ReactElement,
+	{route = '/', token}: { route?: InitialEntry; token?: { value: string; username: string } } = {},
 ) {
-  if (token) {
-    localStorage.setItem('auth_token', token.value)
-    localStorage.setItem('auth_username', token.username)
-  }
-  return render(
-    <MemoryRouter initialEntries={[route]}>
-      <AuthProvider>{ui}</AuthProvider>
-    </MemoryRouter>,
-  )
+	if (token) {
+		localStorage.setItem('auth_token', token.value)
+		localStorage.setItem('auth_username', token.username)
+	}
+	render(
+		<MemoryRouter initialEntries={[route]}>
+			<AuthProvider>{ui}</AuthProvider>
+		</MemoryRouter>,
+	)
 }
 
 export function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
-  return new Response(JSON.stringify(body), {
-    status: 200,
-    headers: { 'content-type': 'application/json' },
-    ...init,
-  })
+	return new Response(JSON.stringify(body), {
+		status: 200,
+		headers: {'content-type': 'application/json'},
+		...init,
+	})
 }

--- a/web-client/tests/utils.tsx
+++ b/web-client/tests/utils.tsx
@@ -1,0 +1,28 @@
+import type { ReactElement } from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import type { InitialEntry } from 'react-router-dom'
+import { render } from '@testing-library/react'
+import { AuthProvider } from '../src/auth'
+
+export function renderWithProviders(
+  ui: ReactElement,
+  { route = '/', token }: { route?: InitialEntry; token?: { value: string; username: string } } = {},
+) {
+  if (token) {
+    localStorage.setItem('auth_token', token.value)
+    localStorage.setItem('auth_username', token.username)
+  }
+  return render(
+    <MemoryRouter initialEntries={[route]}>
+      <AuthProvider>{ui}</AuthProvider>
+    </MemoryRouter>,
+  )
+}
+
+export function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+    ...init,
+  })
+}

--- a/web-client/tsconfig.app.json
+++ b/web-client/tsconfig.app.json
@@ -4,7 +4,7 @@
     "target": "es2023",
     "lib": ["ES2023", "DOM"],
     "module": "esnext",
-    "types": ["vite/client"],
+    "types": ["vite/client", "vitest/globals"],
     "skipLibCheck": true,
 
     /* Bundler mode */
@@ -21,5 +21,5 @@
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src"]
+  "include": ["src", "tests"]
 }

--- a/web-client/vite.config.ts
+++ b/web-client/vite.config.ts
@@ -1,3 +1,4 @@
+/// <reference types="vitest/config" />
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
@@ -5,6 +6,14 @@ import tailwindcss from '@tailwindcss/vite'
 export default defineConfig({
   base: '/team-devsecops/',
   plugins: [react(), tailwindcss()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./tests/setup.ts'],
+    css: false,
+    include: ['tests/**/*.test.{ts,tsx}'],
+    exclude: ['tests/e2e/**', 'node_modules/**', 'dist/**'],
+  },
   server: {
 		// mappings when running in dev mode
     proxy: {

--- a/web-client/vite.config.ts
+++ b/web-client/vite.config.ts
@@ -13,6 +13,10 @@ export default defineConfig({
     css: false,
     include: ['tests/**/*.test.{ts,tsx}'],
     exclude: ['tests/e2e/**', 'node_modules/**', 'dist/**'],
+    reporters: [
+      'default',
+      ['junit', { outputFile: 'test-results/vitest-junit.xml' }],
+    ],
   },
   server: {
 		// mappings when running in dev mode


### PR DESCRIPTION
Adds frontend test coverage for `web-client` and wires it into CI.

## Changes
- **Unit tests (Vitest + RTL)** for pages and helpers: `LoginPage`, `GeneratePage`, `ProfilePage`, `RecipePage`, plus `auth`, `apiError`, and `recipeFormat`. Shared render helpers in `tests/utils.tsx` and jsdom setup in `tests/setup.ts`.
- **E2E smoke test (Playwright)** in `tests/e2e/smoke.spec.ts` with `playwright.config.ts`.
- **Vite/TS config** updated to include the test setup and types.
- **CI**: `.github/workflows/build-client.yml` split into `lint` and `build-test` jobs; `build-test` runs `npm run build`, `npm test`, and Playwright E2E, uploading the Playwright report on failure.

## Test plan
- `npm run lint`, `npm run build`, `npm test`, `npm run test:e2e` all pass locally.
- CI runs the same on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)