### PR TITLE
Deep-linkable recipe pages + session gate

### DIFF
--- a/web-client/src/App.tsx
+++ b/web-client/src/App.tsx
@@ -29,8 +29,9 @@ export default function App() {
             }
           >
             <Route path="/generate" element={<GeneratePage />} />
-            <Route path="/recipe" element={<RecipePage />} />
+            <Route path="/generate/recipe" element={<RecipePage />} />
             <Route path="/library" element={<LibraryPage />} />
+            <Route path="/library/recipe/:recipeId" element={<RecipePage />} />
             <Route path="/profile" element={<ProfilePage />} />
           </Route>
           <Route path="*" element={<NotFoundPage />} />

--- a/web-client/src/apiError.ts
+++ b/web-client/src/apiError.ts
@@ -3,9 +3,9 @@ import type { components } from './api'
 type ErrorResponse = components['schemas']['ErrorResponse']
 
 /**
- * Reads the server's ErrorResponse `message` from a failed response body.
+ * Returns the server's ErrorResponse `message` from a failed response body.
  */
-export async function errorMessage(res: Response, fallback: string): Promise<string> {
+export async function errorMessage(res: Response): Promise<string> {
   try {
     const data = (await res.json()) as Partial<ErrorResponse>
     if (typeof data?.message === 'string' && data.message.trim() !== '') {
@@ -14,5 +14,5 @@ export async function errorMessage(res: Response, fallback: string): Promise<str
   } catch {
     // fall through
   }
-  return fallback
+  return `An error occured. (HTTP ${res.status})`
 }

--- a/web-client/src/auth.tsx
+++ b/web-client/src/auth.tsx
@@ -13,8 +13,7 @@ async function loginRequest(username: string, password: string): Promise<string>
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify({ username, password }),
   })
-  if (res.status === 401) throw new Error(await errorMessage(res, 'Invalid username or password'))
-  if (!res.ok) throw new Error(await errorMessage(res, `Couldn't log in (HTTP ${res.status})`))
+  if (!res.ok) throw new Error(await errorMessage(res))
   const data = (await res.json()) as { token: string }
   return data.token
 }
@@ -26,8 +25,7 @@ async function registerRequest(username: string, password: string): Promise<void
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify({ username, password }),
   })
-  if (res.status === 409) throw new Error(await errorMessage(res, 'Username already taken'))
-  if (!res.ok) throw new Error(await errorMessage(res, `Couldn't sign up (HTTP ${res.status})`))
+  if (!res.ok) throw new Error(await errorMessage(res))
 }
 
 async function logoutRequest(token: string): Promise<void> {

--- a/web-client/src/components/AppLayout.tsx
+++ b/web-client/src/components/AppLayout.tsx
@@ -2,14 +2,15 @@ import { Outlet, useLocation } from 'react-router-dom'
 import { Nav } from './Nav'
 
 const titles: Record<string, string> = {
-  '/generate': 'Cooking Assistant',
-  '/library': 'Library',
-  '/profile': 'Profile',
+  'generate': 'Cooking Assistant',
+  'library': 'Library',
+  'profile': 'Profile',
 }
 
 export function AppLayout() {
   const { pathname } = useLocation()
-  const title = titles[pathname] ?? 'Cooking Assistant'
+  const section = pathname.split('/')[1]
+  const title = titles[section] ?? 'Cooking Assistant'
   const bold = title === 'Cooking Assistant'
 
   return (
@@ -20,7 +21,7 @@ export function AppLayout() {
           {title}
         </header>
         <main className={`mx-auto w-full p-6 pb-24 md:pb-6 ${pathname === '/library' ? 'max-w-6xl' : 'max-w-2xl'}`}>
-          <div key={pathname} className="flex flex-col gap-4 animate-fade-in">
+          <div key={section} className="flex flex-col gap-4 animate-fade-in">
             <Outlet />
           </div>
         </main>

--- a/web-client/src/components/RecipeSaveButton.tsx
+++ b/web-client/src/components/RecipeSaveButton.tsx
@@ -69,7 +69,7 @@ export function RecipeSaveButton({
     try {
       if (savedId != null) {
         const res = await apiFetch(`/recipes/${savedId}`, { method: 'DELETE' })
-        if (!res.ok) throw new Error(await errorMessage(res, 'Could not remove the recipe.'))
+        if (!res.ok) throw new Error(await errorMessage(res))
 
 				// mark as non-stored if in the generated-recipes list
 				const stored = sessionStorage.getItem('generated_recipes')
@@ -95,7 +95,7 @@ export function RecipeSaveButton({
           headers: { 'content-type': 'application/json' },
           body: JSON.stringify(body),
         })
-        if (!res.ok) throw new Error(await errorMessage(res, 'Could not save the recipe.'))
+        if (!res.ok) throw new Error(await errorMessage(res))
         const { id } = (await res.json()) as RecipeCreated
         setSavedId(id)
         onSavedIdChange?.(id)

--- a/web-client/src/components/RecipeSaveButton.tsx
+++ b/web-client/src/components/RecipeSaveButton.tsx
@@ -68,16 +68,15 @@ export function RecipeSaveButton({
     setError(null)
     try {
       if (savedId != null) {
-        const res = await apiFetch(`/api/v1/recipes/${savedId}`, { method: 'DELETE' })
+        const res = await apiFetch(`/recipes/${savedId}`, { method: 'DELETE' })
         if (!res.ok) throw new Error(await errorMessage(res, 'Could not remove the recipe.'))
 
-				// mark as non-stored in sessionStorage
-				for (const key of ['generated_recipes', 'library_recipes']) {
-					const stored = sessionStorage.getItem(key)
-					if (!stored) continue
+				// mark as non-stored if in the generated-recipes list
+				const stored = sessionStorage.getItem('generated_recipes')
+				if (stored) {
 					const recipes = JSON.parse(stored) as { id?: number }[]
 					const next = recipes.map((r) => (r.id === savedId ? { ...r, id: undefined } : r))
-					sessionStorage.setItem(key, JSON.stringify(next))
+					sessionStorage.setItem('generated_recipes', JSON.stringify(next))
 				}
 
         setSavedId(undefined)
@@ -91,7 +90,7 @@ export function RecipeSaveButton({
           portions: recipe.portions,
           nutrients: recipe.nutrients,
         }
-        const res = await apiFetch('/api/v1/recipes', {
+        const res = await apiFetch('/recipes', {
           method: 'POST',
           headers: { 'content-type': 'application/json' },
           body: JSON.stringify(body),

--- a/web-client/src/pages/GeneratePage.tsx
+++ b/web-client/src/pages/GeneratePage.tsx
@@ -46,7 +46,7 @@ export function GeneratePage() {
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify(body),
       })
-      if (!response.ok) throw new Error(await errorMessage(response, `HTTP ${response.status}`))
+      if (!response.ok) throw new Error(await errorMessage(response))
       const data = (await response.json()) as Recipe[]
       setRecipes(data)
       setStatus(data.length === 0 ? 'No recipes returned.' : null)

--- a/web-client/src/pages/GeneratePage.tsx
+++ b/web-client/src/pages/GeneratePage.tsx
@@ -1,11 +1,11 @@
-import { useEffect, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
-import type { components } from '../api'
-import { Button } from '../components/Button'
-import { RecipeCard } from '../components/RecipeCard'
-import { usePressPulse } from '../usePressPulse'
-import { errorMessage } from '../apiError'
-import { SessionExpiredError, useApi } from '../useApi'
+import {useEffect, useState} from 'react'
+import {useNavigate} from 'react-router-dom'
+import type {components} from '../api'
+import {Button} from '../components/Button'
+import {RecipeCard} from '../components/RecipeCard'
+import {usePressPulse} from '../usePressPulse'
+import {errorMessage} from '../apiError'
+import {SessionExpiredError, useApi} from '../useApi'
 
 // id is stored on the recipe once it is saved
 type Recipe = components['schemas']['RecipeInput'] & { id?: number }
@@ -24,6 +24,12 @@ export function GeneratePage() {
   const [status, setStatus] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
 
+	// Confirm the session is still valid
+	useEffect(() => {
+		// on failure, this will automatically redirect to /login
+		apiFetch('/users/profile')
+	}, [apiFetch])
+
   useEffect(() => {
     sessionStorage.setItem('generated_recipes', JSON.stringify(recipes))
   }, [recipes])
@@ -35,7 +41,7 @@ export function GeneratePage() {
     sessionStorage.setItem('recipe_prompt', prompt)
     try {
       const body: RecipeRequest = { prompt }
-      const response = await apiFetch('/api/v1/ai/recipes', {
+		const response = await apiFetch('/ai/recipes', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify(body),
@@ -94,7 +100,7 @@ export function GeneratePage() {
           recipe={recipe}
           recipeId={recipe.id}
           onSavedIdChange={(newId) => handleSavedIdChange(index, newId)}
-          onOpen={() => navigate('/recipe', { state: {index, source: 'generated' } })}
+          onOpen={() => navigate('/generate/recipe', {state: {index}})}
         />
       ))}
     </>

--- a/web-client/src/pages/LibraryPage.tsx
+++ b/web-client/src/pages/LibraryPage.tsx
@@ -23,7 +23,7 @@ export function LibraryPage() {
 		async function load() {
 			try {
 				const res = await apiFetch('/recipes')
-				if (!res.ok) throw new Error(await errorMessage(res, `HTTP ${res.status}`))
+				if (!res.ok) throw new Error(await errorMessage(res))
 				const data = ((await res.json()) as Recipe[]).reverse() // newest recipe first
 				if (cancelled) return
 				setRecipes(data)

--- a/web-client/src/pages/LibraryPage.tsx
+++ b/web-client/src/pages/LibraryPage.tsx
@@ -1,103 +1,100 @@
-import { useEffect, useState } from 'react'
-import { flushSync } from 'react-dom'
-import { Link, useNavigate } from 'react-router-dom'
-import { BookOpenIcon } from '@heroicons/react/24/outline'
-import { BoltIcon, BookmarkIcon } from '@heroicons/react/24/solid'
-import type { components } from '../api'
-import { RecipeCard } from '../components/RecipeCard'
-import { errorMessage } from '../apiError'
-import { SessionExpiredError, useApi } from '../useApi'
+import {useEffect, useState} from 'react'
+import {flushSync} from 'react-dom'
+import {Link, useNavigate} from 'react-router-dom'
+import {BookOpenIcon} from '@heroicons/react/24/outline'
+import {BoltIcon, BookmarkIcon} from '@heroicons/react/24/solid'
+import type {components} from '../api'
+import {RecipeCard} from '../components/RecipeCard'
+import {errorMessage} from '../apiError'
+import {SessionExpiredError, useApi} from '../useApi'
 
 type Recipe = components['schemas']['Recipe']
 
 export function LibraryPage() {
-  const apiFetch = useApi()
-  const navigate = useNavigate()
-  const [recipes, setRecipes] = useState<Recipe[]>([])
-  const [phase, setPhase] = useState<'loading' | 'ready' | 'error'>('loading')
-  const [error, setError] = useState<string | null>(null)
+	const apiFetch = useApi()
+	const navigate = useNavigate()
+	const [recipes, setRecipes] = useState<Recipe[]>([])
+	const [phase, setPhase] = useState<'loading' | 'ready' | 'error'>('loading')
+	const [error, setError] = useState<string | null>(null)
 
-  useEffect(() => {
-    let cancelled = false
-    async function load() {
-      try {
-        const res = await apiFetch('/api/v1/recipes')
-        if (!res.ok) throw new Error(await errorMessage(res, `HTTP ${res.status}`))
-        const data = ((await res.json()) as Recipe[]).reverse() // newest recipe first
-        if (cancelled) return
-        // keep the list so the recipe view can read it (incl. prev/next navigation)
-        sessionStorage.setItem('library_recipes', JSON.stringify(data))
-        setRecipes(data)
-        setPhase('ready')
-      } catch (e) {
-        if (cancelled || e instanceof SessionExpiredError) return
-        setError(`Error: ${e instanceof Error ? e.message : String(e)}`)
-        setPhase('error')
-      }
-    }
-    load()
-    return () => {
-      cancelled = true
-    }
-  }, [apiFetch])
+	useEffect(() => {
+		let cancelled = false
 
-  if (phase === 'loading') return <p className="text-gray-500">Loading…</p>
-  if (phase === 'error') return <p className="text-red-600">{error}</p>
+		async function load() {
+			try {
+				const res = await apiFetch('/recipes')
+				if (!res.ok) throw new Error(await errorMessage(res, `HTTP ${res.status}`))
+				const data = ((await res.json()) as Recipe[]).reverse() // newest recipe first
+				if (cancelled) return
+				setRecipes(data)
+				setPhase('ready')
+			} catch (e) {
+				if (cancelled || e instanceof SessionExpiredError) return
+				setError(`Error: ${e instanceof Error ? e.message : String(e)}`)
+				setPhase('error')
+			}
+		}
 
-  if (recipes.length === 0) {
-    return (
-      <div className="flex min-h-[60vh] flex-col items-center justify-center gap-4 text-center">
-        <BookOpenIcon className="h-12 w-12 text-orange-200" />
-        <div className="flex flex-col gap-1">
-          <h2 className="text-lg font-bold">Your cookbook is empty</h2>
-          <p className="max-w-xs text-gray-500">
-            Nothing saved yet. Cook up some ideas and tap the{' '}
-            <BookmarkIcon className="inline h-4 w-4 -translate-y-0.5 text-orange-400" /> to stash
-            your favourites here.
-          </p>
-        </div>
-        <Link
-          to="/generate"
-          className="flex items-center gap-2 rounded bg-orange-500 px-4 py-2 text-white transition-transform duration-100 hover:scale-98"
-        >
-          <BoltIcon className="h-5 w-5" />
-          Generate a recipe
-        </Link>
-      </div>
-    )
-  }
+		load()
+		return () => {
+			cancelled = true
+		}
+	}, [apiFetch])
 
-  return (
-    <div className="columns-1 gap-4 md:columns-2 lg:columns-3">
-      {recipes.map((recipe, i) => (
-        <div
-          key={recipe.id}
-          className="mb-4 break-inside-avoid"
-          style={{ viewTransitionName: `recipe-card-${recipe.id}` }}
-        >
-          <RecipeCard
-            recipe={recipe}
-            recipeId={recipe.id}
-            onSavedIdChange={(newId) => {
-              if (newId != null) return
+	if (phase === 'loading') return <p className="text-gray-500">Loading…</p>
+	if (phase === 'error') return <p className="text-red-600">{error}</p>
+
+	if (recipes.length === 0) {
+		return (
+			<div className="flex min-h-[60vh] flex-col items-center justify-center gap-4 text-center">
+				<BookOpenIcon className="h-12 w-12 text-orange-200"/>
+				<div className="flex flex-col gap-1">
+					<h2 className="text-lg font-bold">Your cookbook is empty</h2>
+					<p className="max-w-xs text-gray-500">
+						Nothing saved yet. Cook up some ideas and tap the{' '}
+						<BookmarkIcon className="inline h-4 w-4 -translate-y-0.5 text-orange-400"/> to stash
+						your favourites here.
+					</p>
+				</div>
+				<Link
+					to="/generate"
+					className="flex items-center gap-2 rounded bg-orange-500 px-4 py-2 text-white transition-transform duration-100 hover:scale-98"
+				>
+					<BoltIcon className="h-5 w-5"/>
+					Generate a recipe
+				</Link>
+			</div>
+		)
+	}
+
+	return (
+		<div className="columns-1 gap-4 md:columns-2 lg:columns-3">
+			{recipes.map((recipe) => (
+				<div
+					key={recipe.id}
+					className="mb-4 break-inside-avoid"
+					style={{viewTransitionName: `recipe-card-${recipe.id}`}}
+				>
+					<RecipeCard
+						recipe={recipe}
+						recipeId={recipe.id}
+						onSavedIdChange={(newId) => {
+							if (newId != null) return
 
 							// this recipe got deleted, make the others rearrange with a smooth transition
-              const apply = () => {
-                flushSync(() => {
-                  setRecipes((prev) => {
-                    const next = prev.filter((r) => r.id !== recipe.id)
-                    sessionStorage.setItem('library_recipes', JSON.stringify(next))
-                    return next
-                  })
-                })
-              }
-              if (document.startViewTransition) document.startViewTransition(apply)
-              else apply()
-            }}
-            onOpen={() => navigate('/recipe', { state: { index: i, source: 'library' } })}
-          />
-        </div>
-      ))}
-    </div>
-  )
+							const deleteRecipe = () => {
+								flushSync(() => {
+									setRecipes((prev) => prev.filter((r) => r.id !== recipe.id))
+								})
+							}
+							if (document.startViewTransition) document.startViewTransition(deleteRecipe)
+							else deleteRecipe()
+						}}
+						// carry the ordered ids so the recipe page can offer prev/next without re-fetching the list
+						onOpen={() => navigate(`/library/recipe/${recipe.id}`, {state: {ids: recipes.map((r) => r.id)}})}
+					/>
+				</div>
+			))}
+		</div>
+	)
 }

--- a/web-client/src/pages/ProfilePage.tsx
+++ b/web-client/src/pages/ProfilePage.tsx
@@ -61,7 +61,7 @@ export function ProfilePage() {
 	// fetch the currently stored user profile
   useEffect(() => {
     let cancelled = false
-    apiFetch('/api/v1/users/profile')
+    apiFetch('/users/profile')
       .then(async (res) => {
         if (!res.ok) throw new Error(await errorMessage(res, `HTTP ${res.status}`))
         const data = (await res.json()) as UserProfile
@@ -81,7 +81,7 @@ export function ProfilePage() {
   }, [apiFetch])
 
   async function updateProfile(body: UserProfileUpdate): Promise<void> {
-    const res = await apiFetch('/api/v1/users/profile', {
+    const res = await apiFetch('/users/profile', {
       method: 'PUT',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify(body),

--- a/web-client/src/pages/ProfilePage.tsx
+++ b/web-client/src/pages/ProfilePage.tsx
@@ -63,7 +63,7 @@ export function ProfilePage() {
     let cancelled = false
     apiFetch('/users/profile')
       .then(async (res) => {
-        if (!res.ok) throw new Error(await errorMessage(res, `HTTP ${res.status}`))
+        if (!res.ok) throw new Error(await errorMessage(res))
         const data = (await res.json()) as UserProfile
         if (cancelled) return
         const prefs = data.preferences ?? {}
@@ -86,9 +86,7 @@ export function ProfilePage() {
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify(body),
     })
-    if (res.status === 409) throw new Error(await errorMessage(res, 'Username already taken'))
-    if (res.status === 400) throw new Error(await errorMessage(res, 'Invalid request'))
-    if (!res.ok) throw new Error(await errorMessage(res, `HTTP ${res.status}`))
+    if (!res.ok) throw new Error(await errorMessage(res))
   }
 
   async function handleSavePreferences() {

--- a/web-client/src/pages/RecipePage.tsx
+++ b/web-client/src/pages/RecipePage.tsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useRef, useState } from 'react'
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import {
   ArrowPathIcon,
   ArrowRightIcon,
@@ -8,7 +8,7 @@ import {
   PlusIcon,
 } from '@heroicons/react/24/outline'
 import Markdown from 'react-markdown'
-import { Navigate, useLocation, useNavigate } from 'react-router-dom'
+import { Link, Navigate, useLocation, useNavigate, useParams } from 'react-router-dom'
 import type { components } from '../api'
 import { RecipeSaveButton } from '../components/RecipeSaveButton.tsx'
 import { formatQuantity } from '../recipeFormat'
@@ -21,14 +21,12 @@ type HelpRequest = components['schemas']['HelpRequest']
 type HelpResponse = components['schemas']['HelpResponse']
 type HelpEntry = { question: string; answer: string }
 
-type RecipeSource = 'generated' | 'library'
-const SOURCE_STORAGE_KEY: Record<RecipeSource, string> = {
-  generated: 'generated_recipes',
-  library: 'library_recipes',
-}
+type Pagination = { index: number; count: number; onNavigate: (index: number) => void }
 
-function readRecipes(source: RecipeSource): Recipe[] {
-  const stored = sessionStorage.getItem(SOURCE_STORAGE_KEY[source])
+const GENERATED_STORAGE_KEY = 'generated_recipes'
+
+function readGenerated(): Recipe[] {
+  const stored = sessionStorage.getItem(GENERATED_STORAGE_KEY)
   return stored ? (JSON.parse(stored) as Recipe[]) : []
 }
 
@@ -39,26 +37,24 @@ function toggleSetItem(set: Set<number>, item: number): Set<number> {
   return next
 }
 
-// Wrapper that keeps the recipe list and the help histories
 export function RecipePage() {
-  const location = useLocation()
-  const state = location.state as { index?: number; source?: RecipeSource } | null
-  const source: RecipeSource = state?.source ?? 'generated'
-  const [recipes, setRecipes] = useState<Recipe[]>(() => readRecipes(source))
-  const [loadedSource, setLoadedSource] = useState(source)
-  if (loadedSource !== source) {
-    setLoadedSource(source)
-    setRecipes(readRecipes(source))
-  }
-  const index = state?.index ?? 0
-  const recipe = recipes[index]
+  const { pathname } = useLocation()
+  return pathname.startsWith('/library/') ? <LibraryRecipePage key={pathname} /> : <GeneratedRecipePage />
+}
 
+// Generated recipes live in sessionStorage and are paged through by list index in router state.
+function GeneratedRecipePage() {
+  const location = useLocation()
+  const navigate = useNavigate()
+  const index = (location.state as { index?: number } | null)?.index ?? 0
+  const [recipes, setRecipes] = useState<Recipe[]>(() => readGenerated())
   const [helpAnswers, setHelpAnswers] = useState<Record<number, HelpEntry[]>>({})
+  const recipe = recipes[index]
 
   function handleSavedIdChange(newId: number | undefined) {
     setRecipes((prev) => {
       const next = prev.map((prevRecipe, prevIndex) => (prevIndex === index ? { ...prevRecipe, id: newId } : prevRecipe))
-      sessionStorage.setItem(SOURCE_STORAGE_KEY[source], JSON.stringify(next))
+      sessionStorage.setItem(GENERATED_STORAGE_KEY, JSON.stringify(next))
       return next
     })
   }
@@ -69,34 +65,104 @@ export function RecipePage() {
     <RecipeView
       key={index}
       recipe={recipe}
-      recipes={recipes}
-      index={index}
-      source={source}
+      parentPath="/generate"
       onSavedIdChange={handleSavedIdChange}
       answers={helpAnswers[index] ?? []}
-      onAnswer={(entry) =>
-        setHelpAnswers((m) => ({ ...m, [index]: [entry, ...(m[index] ?? [])] }))
+      onAnswer={(entry) => setHelpAnswers((m) => ({ ...m, [index]: [entry, ...(m[index] ?? [])] }))}
+      pagination={{
+        index,
+        count: recipes.length,
+        onNavigate: (i) => navigate('/generate/recipe', { state: { index: i }, replace: true }),
+      }}
+    />
+  )
+}
+
+// Saved recipes are fetched by id on every view, so the API is always the source of truth.
+function LibraryRecipePage() {
+  const params = useParams()
+  const location = useLocation()
+  const navigate = useNavigate()
+  const recipeId = Number(params.recipeId)
+  const recipeIdsInLibrary = (location.state as { ids?: number[] } | null)?.ids
+  const apiFetch = useApi()
+  const [recipe, setRecipe] = useState<Recipe | null>(null)
+  const [phase, setPhase] = useState<'loading' | 'ready' | 'notfound' | 'error'>('loading')
+  const [error, setError] = useState<string | null>(null)
+  const [answers, setAnswers] = useState<HelpEntry[]>([])
+
+  useEffect(() => {
+    let cancelled = false
+    async function load() {
+      try {
+        const res = await apiFetch(`/recipes/${recipeId}`)
+        // 401/403 are handled by apiFetch (redirects to /login)
+        if (res.status === 404) {
+          if (!cancelled) setPhase('notfound')
+          return
+        }
+        if (!res.ok) throw new Error(await errorMessage(res, `HTTP ${res.status}`))
+        const data = (await res.json()) as Recipe
+        if (cancelled) return
+        setRecipe(data)
+        setPhase('ready')
+      } catch (e) {
+        if (cancelled || e instanceof SessionExpiredError) return
+        setError(`Error: ${e instanceof Error ? e.message : String(e)}`)
+        setPhase('error')
       }
+    }
+    load()
+    return () => {
+      cancelled = true
+    }
+  }, [apiFetch, recipeId])
+
+  if (phase === 'loading') return <p className="text-gray-500">Loading…</p>
+  if (phase === 'error') return <p className="text-red-600">{error}</p>
+  if (phase === 'notfound' || !recipe) {
+    return (
+      <div className="flex min-h-[60vh] flex-col items-center justify-center gap-4 text-center">
+        <h2 className="text-lg font-bold">Recipe not found</h2>
+        <p className="max-w-xs text-gray-500">This recipe doesn't exist or has been removed.</p>
+        <Link to="/library" className="text-orange-600 hover:underline">
+          Back to library
+        </Link>
+      </div>
+    )
+  }
+
+  const idx = recipeIdsInLibrary ? recipeIdsInLibrary.indexOf(recipeId) : -1
+  const pagination =
+    recipeIdsInLibrary && recipeIdsInLibrary.length > 1 && idx >= 0
+      ? { index: idx, count: recipeIdsInLibrary.length, onNavigate: (i: number) => navigate(`/library/recipe/${recipeIdsInLibrary[i]}`, { state: { ids: recipeIdsInLibrary } }) }
+      : undefined
+
+  return (
+    <RecipeView
+      recipe={recipe}
+      parentPath="/library"
+      answers={answers}
+      onAnswer={(entry) => setAnswers((a) => [entry, ...a])}
+      pagination={pagination}
     />
   )
 }
 
 function RecipeView({
   recipe,
-  recipes,
-  index,
-  source,
+  parentPath,
   onSavedIdChange,
   answers,
   onAnswer,
+  pagination,
 }: {
   recipe: Recipe
-  recipes: Recipe[]
-  index: number
-  source: RecipeSource
-  onSavedIdChange: (id: number | undefined) => void
+  parentPath: string
+  onSavedIdChange?: (id: number | undefined) => void
   answers: HelpEntry[]
   onAnswer: (entry: HelpEntry) => void
+  pagination?: Pagination
 }) {
   const navigate = useNavigate()
   const apiFetch = useApi()
@@ -122,8 +188,7 @@ function RecipeView({
   }, [helpPrompt])
 
   const scale = recipe.portions ? portions / recipe.portions : 1
-  const navigateToRecipe = (index: number) =>
-    navigate('/recipe', { state: { index, source }, replace: true })
+  const pages = pagination &&  ? pagination : null
 
   async function handleGetHelp() {
     const question = helpPrompt.trim()
@@ -142,7 +207,7 @@ function RecipeView({
         },
         prompt: question,
       }
-      const response = await apiFetch('/api/v1/ai/help', {
+      const response = await apiFetch('/ai/help', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify(body),
@@ -161,11 +226,11 @@ function RecipeView({
 
   return (
     <>
-			{/* Back to /generate */}
+			{/* Back to the section list */}
       <button
         type="button"
         className="flex items-center gap-1 self-start text-gray-500 cursor-pointer transition-transform duration-100 hover:scale-98"
-        onClick={() => navigate(-1)}
+        onClick={() => navigate(parentPath)}
       >
         <ChevronLeftIcon className="h-5 w-5" />
         Back
@@ -174,13 +239,13 @@ function RecipeView({
       <article className="relative w-full rounded-lg border border-gray-200 bg-white p-6 shadow-sm flex flex-col gap-4">
 
 				{/* previous / next recipe (desktop) */}
-        {recipes.length > 1 && (
+        {pages && (
           <>
             <button
               type="button"
               className="hidden lg:flex absolute top-1/2 -left-16 -translate-y-1/2 flex-col items-center gap-1 cursor-pointer text-gray-500 transition-transform duration-100 hover:scale-95 disabled:opacity-40 disabled:hover:scale-100"
-              onClick={() => navigateToRecipe(index - 1)}
-              disabled={index <= 0}
+              onClick={() => pages.onNavigate(pages.index - 1)}
+              disabled={pages.index <= 0}
             >
               <span className="flex h-9 w-9 items-center justify-center rounded-full border border-gray-300 bg-white text-gray-600 shadow-sm">
                 <ChevronLeftIcon className="h-5 w-5" />
@@ -190,8 +255,8 @@ function RecipeView({
             <button
               type="button"
               className="hidden lg:flex absolute top-1/2 -right-16 -translate-y-1/2 flex-col items-center gap-1 cursor-pointer text-gray-500 transition-transform duration-100 hover:scale-95 disabled:opacity-40 disabled:hover:scale-100"
-              onClick={() => navigateToRecipe(index + 1)}
-              disabled={index >= recipes.length - 1}
+              onClick={() => pages.onNavigate(pages.index + 1)}
+              disabled={pages.index >= pages.count - 1}
             >
               <span className="flex h-9 w-9 items-center justify-center rounded-full border border-gray-300 bg-white text-gray-600 shadow-sm">
                 <ChevronRightIcon className="h-5 w-5" />
@@ -209,7 +274,7 @@ function RecipeView({
               recipe={recipe}
               recipeId={recipe.id}
               onSavedIdChange={onSavedIdChange}
-              onDeleted={() => navigate(source === 'library' ? '/library' : '/generate')}
+              onDeleted={() => navigate(parentPath)}
             />
           </div>
           <div className="flex items-center gap-2">
@@ -364,26 +429,26 @@ function RecipeView({
       ))}
 
 			{/* previous / next recipe (mobile) */}
-			{recipes.length > 1 && (
+			{pages && (
         <div className="pointer-events-none fixed inset-x-0 bottom-20 z-20 flex justify-center px-4 md:left-56 lg:hidden">
           <div className="pointer-events-auto flex items-center gap-3 rounded-full border border-gray-200 bg-white/90 py-2 pl-2 pr-2 shadow-lg backdrop-blur">
             <button
               type="button"
               className="flex h-8 w-8 items-center justify-center cursor-pointer text-gray-600 transition-transform duration-100 hover:scale-95 disabled:opacity-40 disabled:hover:scale-100"
-              onClick={() => navigateToRecipe(index - 1)}
-              disabled={index <= 0}
+              onClick={() => pages.onNavigate(pages.index - 1)}
+              disabled={pages.index <= 0}
               aria-label="Previous recipe"
             >
               <ChevronLeftIcon className="h-5 w-5" />
             </button>
             <span className="text-sm text-gray-500 tabular-nums">
-              {index + 1} of {recipes.length}
+              {pages.index + 1} of {pages.count}
             </span>
             <button
               type="button"
               className="flex h-8 w-8 items-center justify-center cursor-pointer text-gray-600 transition-transform duration-100 hover:scale-95 disabled:opacity-40 disabled:hover:scale-100"
-              onClick={() => navigateToRecipe(index + 1)}
-              disabled={index >= recipes.length - 1}
+              onClick={() => pages.onNavigate(pages.index + 1)}
+              disabled={pages.index >= pages.count - 1}
               aria-label="Next recipe"
             >
               <ChevronRightIcon className="h-5 w-5" />
@@ -393,7 +458,7 @@ function RecipeView({
       )}
 
       {/* room to scroll the last card above the floating prev/next bar */}
-      {recipes.length > 1 && <div aria-hidden className="h-24 lg:hidden" />}
+      {pages && <div aria-hidden className="h-24 lg:hidden" />}
     </>
   )
 }

--- a/web-client/src/pages/RecipePage.tsx
+++ b/web-client/src/pages/RecipePage.tsx
@@ -101,7 +101,7 @@ function LibraryRecipePage() {
           if (!cancelled) setPhase('notfound')
           return
         }
-        if (!res.ok) throw new Error(await errorMessage(res, `HTTP ${res.status}`))
+        if (!res.ok) throw new Error(await errorMessage(res))
         const data = (await res.json()) as Recipe
         if (cancelled) return
         setRecipe(data)
@@ -188,7 +188,7 @@ function RecipeView({
   }, [helpPrompt])
 
   const scale = recipe.portions ? portions / recipe.portions : 1
-  const pages = pagination &&  ? pagination : null
+  const pages = pagination && pagination.count > 1 ? pagination : null
 
   async function handleGetHelp() {
     const question = helpPrompt.trim()
@@ -212,7 +212,7 @@ function RecipeView({
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify(body),
       })
-      if (!response.ok) throw new Error(await errorMessage(response, `HTTP ${response.status}`))
+      if (!response.ok) throw new Error(await errorMessage(response))
       const data = (await response.json()) as HelpResponse
       onAnswer({ question, answer: data.response ?? 'No response.' })
       setHelpPrompt('')

--- a/web-client/src/useApi.ts
+++ b/web-client/src/useApi.ts
@@ -1,7 +1,7 @@
 import { useCallback } from 'react'
 import { useAuth } from './auth'
 
-const API_BASE = import.meta.env.VITE_API_BASE ?? ''
+const API_BASE = (import.meta.env.VITE_API_BASE ?? '') + '/api/v1'
 
 export class SessionExpiredError extends Error {
   constructor() {

--- a/web-client/tests/apiError.test.ts
+++ b/web-client/tests/apiError.test.ts
@@ -11,19 +11,16 @@ describe('errorMessage', () => {
   it('returns the server message when present', async () => {
     const res = jsonResponse({ message: 'Username already taken' })
 
-    const message = await errorMessage(res, 'fallback')
+    const message = await errorMessage(res)
 
     expect(message).toBe('Username already taken')
   })
 
-  it('falls back when the body is missing a message or unparseable', async () => {
-    const whitespaceMessage = jsonResponse({ message: '   ' })
+  it('falls back to a status message when the body has no usable message', async () => {
+    const whitespaceMessage = jsonResponse({ message: '   ' }) // status 400
     const garbage = new Response('not json', { status: 500 })
 
-    const fromWhitespace = await errorMessage(whitespaceMessage, 'fallback')
-    const fromGarbage = await errorMessage(garbage, 'fallback')
-
-    expect(fromWhitespace).toBe('fallback')
-    expect(fromGarbage).toBe('fallback')
+    expect(await errorMessage(whitespaceMessage)).toBe('An error occured. (HTTP 400)')
+    expect(await errorMessage(garbage)).toBe('An error occured. (HTTP 500)')
   })
 })

--- a/web-client/tests/e2e/smoke.spec.ts
+++ b/web-client/tests/e2e/smoke.spec.ts
@@ -39,7 +39,7 @@ test('login -> generate -> open recipe -> log out', async ({page}) => {
 	await page.getByRole('button', {name: 'Generate'}).click()
 
 	await page.getByRole('button', {name: /Tomato Pasta/}).click()
-	await expect(page).toHaveURL(/\/recipe$/)
+	await expect(page).toHaveURL(/\/generate\/recipe$/)
 	await expect(page.getByRole('heading', {name: 'Tomato Pasta'})).toBeVisible()
 
 	await page.goto('profile')

--- a/web-client/tests/pages/GeneratePage.test.tsx
+++ b/web-client/tests/pages/GeneratePage.test.tsx
@@ -21,6 +21,7 @@ const fetchMock = vi.fn<typeof fetch>()
 
 beforeEach(() => {
   vi.stubGlobal('fetch', fetchMock)
+  fetchMock.mockResolvedValueOnce(jsonResponse({ username: 'alice' }))
 })
 afterEach(() => {
   fetchMock.mockReset()

--- a/web-client/tests/pages/RecipePage.test.tsx
+++ b/web-client/tests/pages/RecipePage.test.tsx
@@ -1,9 +1,10 @@
 import {Route, Routes} from 'react-router-dom'
 import {screen} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import {afterEach, beforeEach, vi} from 'vitest'
 import type {components} from '../../src/api'
 import {RecipePage} from '../../src/pages/RecipePage'
-import {renderWithProviders} from '../utils'
+import {jsonResponse, renderWithProviders} from '../utils'
 
 type Recipe = components['schemas']['Recipe']
 
@@ -17,15 +18,38 @@ const a: Recipe = {
 }
 const b: Recipe = {...a, id: 2, title: 'Pesto Pasta'}
 
-function render(index = 0, recipes: Recipe[] = [a, b]) {
+const fetchMock = vi.fn<typeof fetch>()
+
+beforeEach(() => {
+	vi.stubGlobal('fetch', fetchMock)
+})
+afterEach(() => {
+	fetchMock.mockReset()
+	vi.unstubAllGlobals()
+})
+
+function renderGeneratedRecipe(index = 0, recipes: Recipe[] = [a, b]) {
 	sessionStorage.setItem('generated_recipes', JSON.stringify(recipes))
 	renderWithProviders(
 		<Routes>
 			<Route path="/generate" element={<div>generate page</div>}/>
-			<Route path="/recipe" element={<RecipePage/>}/>
+			<Route path="/generate/recipe" element={<RecipePage/>}/>
 		</Routes>,
 		{
-			route: {pathname: '/recipe', state: {index}},
+			route: {pathname: '/generate/recipe', state: {index}},
+			token: {value: 'tkn', username: 'alice'},
+		},
+	)
+}
+
+function renderLibraryRecipe(recipeId: number, ids?: number[]) {
+	renderWithProviders(
+		<Routes>
+			<Route path="/library" element={<div>library page</div>}/>
+			<Route path="/library/recipe/:recipeId" element={<RecipePage/>}/>
+		</Routes>,
+		{
+			route: ids ? {pathname: `/library/recipe/${recipeId}`, state: {ids}} : `/library/recipe/${recipeId}`,
 			token: {value: 'tkn', username: 'alice'},
 		},
 	)
@@ -34,7 +58,7 @@ function render(index = 0, recipes: Recipe[] = [a, b]) {
 describe('RecipePage', () => {
 	it('scales ingredient quantities and kcal when portions are doubled', async () => {
 		const user = userEvent.setup()
-		render(0)
+		renderGeneratedRecipe(0)
 
 		// baseline: 4 pcs tomato, 500 kcal at 2 portions
 		expect(screen.getByText(/4 pcs tomato/i)).toBeInTheDocument()
@@ -51,10 +75,39 @@ describe('RecipePage', () => {
 	})
 
 	it('disables Previous on the first recipe and Next on the last', () => {
-		render(0)
+		renderGeneratedRecipe(0)
 
 		// mobile prev/next is the bottom bar; assert via aria-label
 		expect(screen.getByRole('button', {name: 'Previous recipe'})).toBeDisabled()
 		expect(screen.getByRole('button', {name: 'Next recipe'})).toBeEnabled()
+	})
+
+	it('fetches the library recipe named by the id in the URL', async () => {
+		fetchMock.mockResolvedValueOnce(jsonResponse(b))
+		renderLibraryRecipe(2)
+
+		expect(await screen.findByRole('heading', {name: 'Pesto Pasta'})).toBeInTheDocument()
+		expect(fetchMock.mock.calls[0][0]).toContain('/recipes/2')
+		// no id list in state (cold deep-link) → no prev/next carousel
+		expect(screen.queryByRole('button', {name: 'Next recipe'})).not.toBeInTheDocument()
+	})
+
+	it('offers prev/next when the ordered id list is passed in state', async () => {
+		fetchMock.mockResolvedValueOnce(jsonResponse(b))
+		renderLibraryRecipe(2, [1, 2, 3])
+
+		expect(await screen.findByRole('heading', {name: 'Pesto Pasta'})).toBeInTheDocument()
+		// recipe 2 sits between 1 and 3
+		expect(screen.getByRole('button', {name: 'Previous recipe'})).toBeEnabled()
+		expect(screen.getByRole('button', {name: 'Next recipe'})).toBeEnabled()
+		// '2 of 3' is only shown on mobile, but it's in the document anyway
+		expect(screen.getByText('2 of 3')).toBeInTheDocument()
+	})
+
+	it('shows a not-found message when the recipe does not exist', async () => {
+		fetchMock.mockResolvedValueOnce(jsonResponse({message: 'nope'}, {status: 404}))
+		renderLibraryRecipe(999)
+
+		expect(await screen.findByText('Recipe not found')).toBeInTheDocument()
 	})
 })


### PR DESCRIPTION
## Changes
- Change URL to `/generate/recipe`, `/library/recipe/:recipeId` instead of `/recipe`, highlight the active route in the navbar
- Library recipes fetched by id per view instead of storing it in the session
- `errorMessage`: dropped fallback param, use the server error message and default to `An error occured. (HTTP <status>)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)