### PR TITLE
Autosave taste preferences as you type

### DIFF
--- a/web-client/src/components/SaveIndicator.tsx
+++ b/web-client/src/components/SaveIndicator.tsx
@@ -1,19 +1,21 @@
-import { CheckIcon } from '@heroicons/react/24/outline'
+import { CheckIcon, ExclamationTriangleIcon } from '@heroicons/react/24/outline'
 
-export type SaveStatus = 'idle' | 'saving' | 'resaving' | 'saved'
+export type SaveStatus = 'idle' | 'saving' | 'resaving' | 'saved' | 'error'
 
 const labels: Record<SaveStatus, string> = {
   idle: '',
   saving: 'Saving…',
   resaving: 'Saved, saving latest changes…',
   saved: 'Saved',
+  error: 'Could not save',
 }
 
-// Spinner / check overlay shown beside an autosaved field.
-//  - saving:   spinner only (typing or request in flight)
+// Spinner / check / warning overlay shown beside an autosaved field.
+//  - saving:   spinner only (a request is in flight)
 //  - resaving: spinner with a check in its centre (a save landed but newer
 //              edits are still being persisted)
-//  - saved:    green check that fades out once everything is persisted
+//  - saved:    green check that lingers, then fades out
+//  - error:    amber warning sign that stays until the next edit
 export function SaveIndicator({
   status,
   className = '',
@@ -41,6 +43,12 @@ export function SaveIndicator({
         <CheckIcon
           data-testid="save-check"
           className="h-5 w-5 text-green-600 stroke-[3] animate-fade-out"
+        />
+      )}
+      {status === 'error' && (
+        <ExclamationTriangleIcon
+          data-testid="save-error"
+          className="h-5 w-5 text-amber-500 stroke-[2.5] animate-fade-in"
         />
       )}
     </span>

--- a/web-client/src/components/SaveIndicator.tsx
+++ b/web-client/src/components/SaveIndicator.tsx
@@ -1,0 +1,48 @@
+import { CheckIcon } from '@heroicons/react/24/outline'
+
+export type SaveStatus = 'idle' | 'saving' | 'resaving' | 'saved'
+
+const labels: Record<SaveStatus, string> = {
+  idle: '',
+  saving: 'Saving…',
+  resaving: 'Saved, saving latest changes…',
+  saved: 'Saved',
+}
+
+// Spinner / check overlay shown beside an autosaved field.
+//  - saving:   spinner only (typing or request in flight)
+//  - resaving: spinner with a check in its centre (a save landed but newer
+//              edits are still being persisted)
+//  - saved:    green check that fades out once everything is persisted
+export function SaveIndicator({
+  status,
+  className = '',
+}: {
+  status: SaveStatus
+  className?: string
+}) {
+  return (
+    <span
+      className={`pointer-events-none flex h-5 w-5 items-center justify-center ${className}`}
+      role="status"
+      aria-label={labels[status]}
+      data-status={status}
+    >
+      {(status === 'saving' || status === 'resaving') && (
+        <span
+          data-testid="save-spinner"
+          className="absolute h-5 w-5 animate-spin rounded-full border-2 border-gray-300 border-t-orange-500"
+        />
+      )}
+      {status === 'resaving' && (
+        <CheckIcon className="relative h-3 w-3 text-green-600 stroke-[3]" />
+      )}
+      {status === 'saved' && (
+        <CheckIcon
+          data-testid="save-check"
+          className="h-5 w-5 text-green-600 stroke-[3] animate-fade-out"
+        />
+      )}
+    </span>
+  )
+}

--- a/web-client/src/components/SaveIndicator.tsx
+++ b/web-client/src/components/SaveIndicator.tsx
@@ -10,12 +10,6 @@ const labels: Record<SaveStatus, string> = {
   error: 'Could not save',
 }
 
-// Spinner / check / warning overlay shown beside an autosaved field.
-//  - saving:   spinner only (a request is in flight)
-//  - resaving: spinner with a check in its centre (a save landed but newer
-//              edits are still being persisted)
-//  - saved:    green check that lingers, then fades out
-//  - error:    amber warning sign that stays until the next edit
 export function SaveIndicator({
   status,
   className = '',

--- a/web-client/src/index.css
+++ b/web-client/src/index.css
@@ -35,4 +35,17 @@
       transform: scale(0.92);
     }
   }
+
+  /* checkmark dismissal once a field is saved and idle again */
+  --animate-fade-out: fade-out 400ms ease-in forwards;
+  @keyframes fade-out {
+    from {
+      opacity: 1;
+      transform: scale(1);
+    }
+    to {
+      opacity: 0;
+      transform: scale(0.6);
+    }
+  }
 }

--- a/web-client/src/index.css
+++ b/web-client/src/index.css
@@ -36,14 +36,15 @@
     }
   }
 
-  /* checkmark dismissal once a field is saved and idle again */
-  --animate-fade-out: fade-out 400ms ease-in forwards;
+  /* checkmark holds for a moment once a field is saved, then fades away */
+  --animate-fade-out: fade-out 1500ms ease-in forwards;
   @keyframes fade-out {
-    from {
+    0%,
+    66% {
       opacity: 1;
       transform: scale(1);
     }
-    to {
+    100% {
       opacity: 0;
       transform: scale(0.6);
     }

--- a/web-client/src/pages/ProfilePage.tsx
+++ b/web-client/src/pages/ProfilePage.tsx
@@ -23,6 +23,10 @@ type PrefsDraft = { aboutMe: string[]; diet: string[]; allergies: string[] }
 
 const trimList = (xs: string[]) => xs.map((x) => x.trim()).filter((x) => x !== '')
 
+// Abort a profile save that the server never answers, so the indicator can't
+// stay stuck on the spinner forever.
+const SAVE_TIMEOUT_MS = 8000
+
 const allergyPlaceholders = [
   'e.g. peanuts',
   'e.g. shellfish',
@@ -86,11 +90,23 @@ export function ProfilePage() {
   }, [apiFetch])
 
   async function updateProfile(body: UserProfileUpdate): Promise<void> {
-    const res = await apiFetch('/api/v1/users/profile', {
-      method: 'PUT',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify(body),
-    })
+    let res: Response
+    try {
+      res = await apiFetch('/api/v1/users/profile', {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+        // Don't let a dead/unreachable server leave the save spinner hanging.
+        signal: AbortSignal.timeout(SAVE_TIMEOUT_MS),
+      })
+    } catch (e) {
+      // A timed-out request (DOMException) or a refused/unreachable connection
+      // (fetch rejects with a TypeError) both mean: the server isn't there.
+      if ((e instanceof DOMException && e.name === 'TimeoutError') || e instanceof TypeError) {
+        throw new Error("Couldn't reach the server", { cause: e })
+      }
+      throw e
+    }
     if (res.status === 409) throw new Error(await errorMessage(res, 'Username already taken'))
     if (res.status === 400) throw new Error(await errorMessage(res, 'Invalid request'))
     if (!res.ok) throw new Error(await errorMessage(res, `HTTP ${res.status}`))

--- a/web-client/src/pages/ProfilePage.tsx
+++ b/web-client/src/pages/ProfilePage.tsx
@@ -9,12 +9,19 @@ import type { components } from '../api'
 import { useAuth } from '../auth'
 import { Button } from '../components/Button'
 import { PasswordInput } from '../components/PasswordInput'
+import { SaveIndicator } from '../components/SaveIndicator'
 import { usePressPulse } from '../usePressPulse'
+import { usePrefsAutosave } from '../usePrefsAutosave'
 import { errorMessage } from '../apiError'
 import { SessionExpiredError, useApi } from '../useApi'
 
 type UserProfile = components['schemas']['UserProfile']
 type UserProfileUpdate = components['schemas']['UserProfileUpdate']
+
+// raw (un-trimmed) preferences as held by the inputs
+type PrefsDraft = { aboutMe: string[]; diet: string[]; allergies: string[] }
+
+const trimList = (xs: string[]) => xs.map((x) => x.trim()).filter((x) => x !== '')
 
 const allergyPlaceholders = [
   'e.g. peanuts',
@@ -39,7 +46,6 @@ export function ProfilePage() {
   const apiFetch = useApi()
   const navigate = useNavigate()
 
-  const [prefsBtnRef, pulsePrefs] = usePressPulse<HTMLButtonElement>()
   const [usernameBtnRef, pulseUsername] = usePressPulse<HTMLButtonElement>()
   const [passwordBtnRef, pulsePassword] = usePressPulse<HTMLButtonElement>()
 
@@ -54,7 +60,6 @@ export function ProfilePage() {
   const [prefsStatus, setPrefsStatus] = useState<{ kind: 'error' | 'ok'; msg: string } | null>(null)
   const [usernameStatus, setUsernameStatus] = useState<{ kind: 'error' | 'ok'; msg: string } | null>(null)
   const [passwordStatus, setPasswordStatus] = useState<{ kind: 'error' | 'ok'; msg: string } | null>(null)
-  const [prefsSaving, setPrefsSaving] = useState(false)
   const [usernameSaving, setUsernameSaving] = useState(false)
   const [passwordSaving, setPasswordSaving] = useState(false)
 
@@ -91,25 +96,25 @@ export function ProfilePage() {
     if (!res.ok) throw new Error(await errorMessage(res, `HTTP ${res.status}`))
   }
 
-  async function handleSavePreferences() {
-    pulsePrefs()
-    setPrefsSaving(true)
-    setPrefsStatus(null)
-    try {
-      await updateProfile({
+  const { statuses: prefsStatuses, notifyEdit } = usePrefsAutosave<PrefsDraft>({
+    save: (draft) =>
+      updateProfile({
         preferences: {
-          diet: diet.map((d) => d.trim()).filter((d) => d !== ''),
-          allergies: allergies.map((a) => a.trim()).filter((a) => a !== ''),
-          aboutMe: aboutMe.map((a) => a.trim()).filter((a) => a !== ''),
+          diet: trimList(draft.diet),
+          allergies: trimList(draft.allergies),
+          aboutMe: trimList(draft.aboutMe),
         },
-      })
-      setPrefsStatus({ kind: 'ok', msg: 'Preferences saved' })
-    } catch (e) {
-      if (e instanceof SessionExpiredError) return
-      setPrefsStatus({ kind: 'error', msg: e instanceof Error ? e.message : String(e) })
-    } finally {
-      setPrefsSaving(false)
-    }
+      }),
+    onError: (err) => {
+      if (err instanceof SessionExpiredError) return
+      setPrefsStatus({ kind: 'error', msg: err instanceof Error ? err.message : String(err) })
+    },
+  })
+
+  // record an edit to one preferences field and (debounced) autosave the lot
+  function editPrefs(field: string, draft: PrefsDraft) {
+    setPrefsStatus(null)
+    notifyEdit(field, draft)
   }
 
   async function handleUpdateUsername() {
@@ -181,43 +186,60 @@ export function ProfilePage() {
       </div>
 
       <div className="w-full max-w-md rounded-lg border border-gray-200 bg-white p-6 shadow-sm self-center md:self-start">
-        <form
-          className="flex flex-col gap-4"
-          onSubmit={(e) => {
-            e.preventDefault()
-            handleSavePreferences()
-          }}
-        >
+        {/* taste preferences autosave as you type — no submit button */}
+        <div className="flex flex-col gap-4">
           <h2 className="text-lg font-bold">Taste preferences</h2>
 
           <label className="flex flex-col gap-1">
             <span className="font-medium">About me</span>
-            <textarea
-              className="w-full border border-gray-300 rounded p-2"
-              rows={3}
-              value={aboutMe[0] ?? ''}
-              onChange={(e) => setAboutMe([e.target.value])}
-              placeholder="e.g. I cook for a family of four and love spicy food"
-            />
+            <div className="relative">
+              <textarea
+                className="w-full border border-gray-300 rounded p-2 pr-9"
+                rows={3}
+                value={aboutMe[0] ?? ''}
+                onChange={(e) => {
+                  const next = [e.target.value]
+                  setAboutMe(next)
+                  editPrefs('aboutMe', { aboutMe: next, diet, allergies })
+                }}
+                placeholder="e.g. I cook for a family of four and love spicy food"
+              />
+              <SaveIndicator
+                status={prefsStatuses['aboutMe'] ?? 'idle'}
+                className="absolute right-2 top-2"
+              />
+            </div>
           </label>
 
           <div className="flex flex-col gap-1">
             <span className="font-medium">Diet</span>
             {diet.map((d, i) => (
               <div key={i} className="flex items-center gap-2">
-                <input
-                  type="text"
-                  className="w-full border border-gray-300 rounded p-2"
-                  value={d}
-                  onChange={(e) =>
-                    setDiet(diet.map((x, j) => (j === i ? e.target.value : x)))
-                  }
-                  placeholder={dietPlaceholders[i % dietPlaceholders.length]}
-                />
+                <div className="relative flex-1">
+                  <input
+                    type="text"
+                    className="w-full border border-gray-300 rounded p-2 pr-9"
+                    value={d}
+                    onChange={(e) => {
+                      const next = diet.map((x, j) => (j === i ? e.target.value : x))
+                      setDiet(next)
+                      editPrefs(`diet:${i}`, { aboutMe, diet: next, allergies })
+                    }}
+                    placeholder={dietPlaceholders[i % dietPlaceholders.length]}
+                  />
+                  <SaveIndicator
+                    status={prefsStatuses[`diet:${i}`] ?? 'idle'}
+                    className="absolute right-2 top-1/2 -translate-y-1/2"
+                  />
+                </div>
                 <button
                   type="button"
                   className="cursor-pointer text-gray-400 hover:text-red-600 transition-transform duration-100 hover:scale-98"
-                  onClick={() => setDiet(diet.filter((_, j) => j !== i))}
+                  onClick={() => {
+                    const next = diet.filter((_, j) => j !== i)
+                    setDiet(next)
+                    editPrefs('diet', { aboutMe, diet: next, allergies })
+                  }}
                 >
                   <TrashIcon className="h-5 w-5" />
                 </button>
@@ -239,19 +261,31 @@ export function ProfilePage() {
             <span className="font-medium">Allergies</span>
             {allergies.map((allergy, i) => (
               <div key={i} className="flex items-center gap-2">
-                <input
-                  type="text"
-                  className="w-full border border-gray-300 rounded p-2"
-                  value={allergy}
-                  onChange={(e) =>
-                    setAllergies(allergies.map((a, j) => (j === i ? e.target.value : a)))
-                  }
-                  placeholder={allergyPlaceholders[i % allergyPlaceholders.length]}
-                />
+                <div className="relative flex-1">
+                  <input
+                    type="text"
+                    className="w-full border border-gray-300 rounded p-2 pr-9"
+                    value={allergy}
+                    onChange={(e) => {
+                      const next = allergies.map((a, j) => (j === i ? e.target.value : a))
+                      setAllergies(next)
+                      editPrefs(`allergies:${i}`, { aboutMe, diet, allergies: next })
+                    }}
+                    placeholder={allergyPlaceholders[i % allergyPlaceholders.length]}
+                  />
+                  <SaveIndicator
+                    status={prefsStatuses[`allergies:${i}`] ?? 'idle'}
+                    className="absolute right-2 top-1/2 -translate-y-1/2"
+                  />
+                </div>
                 <button
                   type="button"
                   className="cursor-pointer text-gray-400 hover:text-red-600 transition-transform duration-100 hover:scale-98"
-                  onClick={() => setAllergies(allergies.filter((_, j) => j !== i))}
+                  onClick={() => {
+                    const next = allergies.filter((_, j) => j !== i)
+                    setAllergies(next)
+                    editPrefs('allergies', { aboutMe, diet, allergies: next })
+                  }}
                 >
                   <TrashIcon className="h-5 w-5" />
                 </button>
@@ -269,16 +303,12 @@ export function ProfilePage() {
             </button>
           </div>
 
-          <Button ref={prefsBtnRef} type="submit" className="self-center" disabled={prefsSaving}>
-            {prefsSaving ? 'Saving…' : 'Update taste preferences'}
-          </Button>
-
           {prefsStatus && (
             <p className={prefsStatus.kind === 'error' ? 'text-red-600' : 'text-green-600'}>
               {prefsStatus.msg}
             </p>
           )}
-        </form>
+        </div>
       </div>
 
       <div className="w-full max-w-md rounded-lg border border-gray-200 bg-white p-6 shadow-sm self-center md:self-start">

--- a/web-client/src/pages/ProfilePage.tsx
+++ b/web-client/src/pages/ProfilePage.tsx
@@ -18,13 +18,14 @@ import { SessionExpiredError, useApi } from '../useApi'
 type UserProfile = components['schemas']['UserProfile']
 type UserProfileUpdate = components['schemas']['UserProfileUpdate']
 
-// raw (un-trimmed) preferences as held by the inputs
+// un-trimmed preferences as held by the inputs
 type PrefsDraft = { aboutMe: string[]; diet: string[]; allergies: string[] }
 
 const trimList = (xs: string[]) => xs.map((x) => x.trim()).filter((x) => x !== '')
 
-// Abort a profile save that the server never answers, so the indicator can't
-// stay stuck on the spinner forever.
+const arrayWithout = (array: string[], index: number | null) =>
+  index === null ? array : array.filter((_, i) => i !== index)
+
 const SAVE_TIMEOUT_MS = 8000
 
 const allergyPlaceholders = [
@@ -60,6 +61,8 @@ export function ProfilePage() {
   const [aboutMe, setAboutMe] = useState<string[]>([])
   const [diet, setDiet] = useState<string[]>([''])
   const [allergies, setAllergies] = useState<string[]>(['', ''])
+  const [pendingDietDeletion, setPendingDietDeletion] = useState<number | null>(null)
+  const [pendingAllergyDeletion, setPendingAllergyDeletion] = useState<number | null>(null)
 
   const [prefsStatus, setPrefsStatus] = useState<{ kind: 'error' | 'ok'; msg: string } | null>(null)
   const [usernameStatus, setUsernameStatus] = useState<{ kind: 'error' | 'ok'; msg: string } | null>(null)
@@ -96,12 +99,9 @@ export function ProfilePage() {
         method: 'PUT',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify(body),
-        // Don't let a dead/unreachable server leave the save spinner hanging.
         signal: AbortSignal.timeout(SAVE_TIMEOUT_MS),
       })
     } catch (e) {
-      // A timed-out request (DOMException) or a refused/unreachable connection
-      // (fetch rejects with a TypeError) both mean: the server isn't there.
       if ((e instanceof DOMException && e.name === 'TimeoutError') || e instanceof TypeError) {
         throw new Error("Couldn't reach the server", { cause: e })
       }
@@ -112,25 +112,56 @@ export function ProfilePage() {
     if (!res.ok) throw new Error(await errorMessage(res, `HTTP ${res.status}`))
   }
 
+  const savePrefs = (draft: PrefsDraft) =>
+    updateProfile({
+      preferences: {
+        diet: trimList(draft.diet),
+        allergies: trimList(draft.allergies),
+        aboutMe: trimList(draft.aboutMe),
+      },
+    })
+
   const { statuses: prefsStatuses, notifyEdit } = usePrefsAutosave<PrefsDraft>({
-    save: (draft) =>
-      updateProfile({
-        preferences: {
-          diet: trimList(draft.diet),
-          allergies: trimList(draft.allergies),
-          aboutMe: trimList(draft.aboutMe),
-        },
-      }),
+    save: savePrefs,
     onError: (err) => {
       if (err instanceof SessionExpiredError) return
       setPrefsStatus({ kind: 'error', msg: err instanceof Error ? err.message : String(err) })
     },
   })
 
-  // record an edit to one preferences field and (debounced) autosave the lot
+  // preferences without those that are currently being delted
+  const livePrefs = (overrides: Partial<PrefsDraft> = {}): PrefsDraft => ({
+    aboutMe: overrides.aboutMe ?? aboutMe,
+    diet: arrayWithout(overrides.diet ?? diet, pendingDietDeletion),
+    allergies: arrayWithout(overrides.allergies ?? allergies, pendingAllergyDeletion),
+  })
+
   function editPrefs(field: string, draft: PrefsDraft) {
     setPrefsStatus(null)
     notifyEdit(field, draft)
+  }
+
+  async function deleteRow(list: 'diet' | 'allergies', index: number) {
+    const setPending = list === 'diet' ? setPendingDietDeletion : setPendingAllergyDeletion
+    const setValues = list === 'diet' ? setDiet : setAllergies
+
+    setPending(index)
+    setPrefsStatus(null)
+    try {
+      await savePrefs(
+        livePrefs(
+          list === 'diet'
+            ? { diet: arrayWithout(diet, index) }
+            : { allergies: arrayWithout(allergies, index) },
+        ),
+      )
+      setValues((cur) => cur.filter((_, i) => i !== index))
+      setPending(null)
+    } catch (e) {
+      setPending(null)
+      if (e instanceof SessionExpiredError) return
+      setPrefsStatus({ kind: 'error', msg: e instanceof Error ? e.message : String(e) })
+    }
   }
 
   async function handleUpdateUsername() {
@@ -216,7 +247,7 @@ export function ProfilePage() {
                 onChange={(e) => {
                   const next = [e.target.value]
                   setAboutMe(next)
-                  editPrefs('aboutMe', { aboutMe: next, diet, allergies })
+                  editPrefs('aboutMe', livePrefs({ aboutMe: next }))
                 }}
                 placeholder="e.g. I cook for a family of four and love spicy food"
               />
@@ -230,16 +261,20 @@ export function ProfilePage() {
           <div className="flex flex-col gap-1">
             <span className="font-medium">Diet</span>
             {diet.map((d, i) => (
-              <div key={i} className="flex items-center gap-2">
+              <div
+                key={i}
+                className={`flex items-center gap-2 ${pendingDietDeletion === i ? 'opacity-50' : ''}`}
+              >
                 <div className="relative flex-1">
                   <input
                     type="text"
-                    className="w-full border border-gray-300 rounded p-2 pr-9"
+                    className="w-full border border-gray-300 rounded p-2 pr-9 disabled:bg-gray-100"
                     value={d}
+                    disabled={pendingDietDeletion === i}
                     onChange={(e) => {
                       const next = diet.map((x, j) => (j === i ? e.target.value : x))
                       setDiet(next)
-                      editPrefs(`diet:${i}`, { aboutMe, diet: next, allergies })
+                      editPrefs(`diet:${i}`, livePrefs({ diet: next }))
                     }}
                     placeholder={dietPlaceholders[i % dietPlaceholders.length]}
                   />
@@ -250,12 +285,9 @@ export function ProfilePage() {
                 </div>
                 <button
                   type="button"
-                  className="cursor-pointer text-gray-400 hover:text-red-600 transition-transform duration-100 hover:scale-98"
-                  onClick={() => {
-                    const next = diet.filter((_, j) => j !== i)
-                    setDiet(next)
-                    editPrefs('diet', { aboutMe, diet: next, allergies })
-                  }}
+                  className="cursor-pointer text-gray-400 hover:text-red-600 transition-transform duration-100 hover:scale-98 disabled:cursor-not-allowed disabled:text-gray-300 disabled:hover:text-gray-300 disabled:hover:scale-100"
+                  disabled={pendingDietDeletion !== null}
+                  onClick={() => deleteRow('diet', i)}
                 >
                   <TrashIcon className="h-5 w-5" />
                 </button>
@@ -276,16 +308,20 @@ export function ProfilePage() {
           <div className="flex flex-col gap-1">
             <span className="font-medium">Allergies</span>
             {allergies.map((allergy, i) => (
-              <div key={i} className="flex items-center gap-2">
+              <div
+                key={i}
+                className={`flex items-center gap-2 ${pendingAllergyDeletion === i ? 'opacity-50' : ''}`}
+              >
                 <div className="relative flex-1">
                   <input
                     type="text"
-                    className="w-full border border-gray-300 rounded p-2 pr-9"
+                    className="w-full border border-gray-300 rounded p-2 pr-9 disabled:bg-gray-100"
                     value={allergy}
+                    disabled={pendingAllergyDeletion === i}
                     onChange={(e) => {
                       const next = allergies.map((a, j) => (j === i ? e.target.value : a))
                       setAllergies(next)
-                      editPrefs(`allergies:${i}`, { aboutMe, diet, allergies: next })
+                      editPrefs(`allergies:${i}`, livePrefs({ allergies: next }))
                     }}
                     placeholder={allergyPlaceholders[i % allergyPlaceholders.length]}
                   />
@@ -296,12 +332,9 @@ export function ProfilePage() {
                 </div>
                 <button
                   type="button"
-                  className="cursor-pointer text-gray-400 hover:text-red-600 transition-transform duration-100 hover:scale-98"
-                  onClick={() => {
-                    const next = allergies.filter((_, j) => j !== i)
-                    setAllergies(next)
-                    editPrefs('allergies', { aboutMe, diet, allergies: next })
-                  }}
+                  className="cursor-pointer text-gray-400 hover:text-red-600 transition-transform duration-100 hover:scale-98 disabled:cursor-not-allowed disabled:text-gray-300 disabled:hover:text-gray-300 disabled:hover:scale-100"
+                  disabled={pendingAllergyDeletion !== null}
+                  onClick={() => deleteRow('allergies', i)}
                 >
                   <TrashIcon className="h-5 w-5" />
                 </button>

--- a/web-client/src/pages/ProfilePage.tsx
+++ b/web-client/src/pages/ProfilePage.tsx
@@ -92,14 +92,15 @@ export function ProfilePage() {
     }
   }, [apiFetch])
 
-  async function updateProfile(body: UserProfileUpdate): Promise<void> {
+  async function updateProfile(body: UserProfileUpdate, keepalive = false): Promise<void> {
     let res: Response
     try {
       res = await apiFetch('/users/profile', {
         method: 'PUT',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify(body),
-        signal: AbortSignal.timeout(SAVE_TIMEOUT_MS),
+        // keepalive lets a save fired on reload/close outlive the page
+        ...(keepalive ? { keepalive: true } : { signal: AbortSignal.timeout(SAVE_TIMEOUT_MS) }),
       })
     } catch (e) {
       if ((e instanceof DOMException && e.name === 'TimeoutError') || e instanceof TypeError) {
@@ -112,14 +113,17 @@ export function ProfilePage() {
     if (!res.ok) throw new Error(await errorMessage(res, `HTTP ${res.status}`))
   }
 
-  const savePrefs = (draft: PrefsDraft) =>
-    updateProfile({
-      preferences: {
-        diet: trimList(draft.diet),
-        allergies: trimList(draft.allergies),
-        aboutMe: trimList(draft.aboutMe),
+  const savePrefs = (draft: PrefsDraft, keepalive = false) =>
+    updateProfile(
+      {
+        preferences: {
+          diet: trimList(draft.diet),
+          allergies: trimList(draft.allergies),
+          aboutMe: trimList(draft.aboutMe),
+        },
       },
-    })
+      keepalive,
+    )
 
   const { statuses: prefsStatuses, notifyEdit } = usePrefsAutosave<PrefsDraft>({
     save: savePrefs,

--- a/web-client/src/usePrefsAutosave.ts
+++ b/web-client/src/usePrefsAutosave.ts
@@ -4,16 +4,11 @@ import type { SaveStatus } from './components/SaveIndicator'
 // How long to wait after the last keystroke before persisting.
 const SAVE_DELAY_MS = 400
 // How long a request may run before we bother showing the spinner — fast saves
-// finish within this window and never flicker one.
+// finish within this window
 const SPINNER_DELAY_MS = 300
-// How long the green check lingers (it holds, then fades — matches the
-// fade-out animation) before the indicator clears.
+// How long the green checkmark lingers before the indicator clears.
 const CHECKMARK_MS = 1500
 
-// Drives debounced autosave for a set of named fields that share a single
-// payload (here: the whole taste-preferences object). Each field gets its own
-// status so the spinner / checkmark can be rendered next to the input the user
-// is actually editing, even though one request persists everything at once.
 export function usePrefsAutosave<P>(options: {
   save: (payload: P) => Promise<void>
   onError: (error: unknown) => void
@@ -26,8 +21,6 @@ export function usePrefsAutosave<P>(options: {
     spinnerDelay = SPINNER_DELAY_MS,
     checkmarkMs = CHECKMARK_MS,
   } = options
-  // Keep the latest callbacks in refs so the timer-driven logic never closes
-  // over a stale version.
   const saveRef = useRef(options.save)
   const onErrorRef = useRef(options.onError)
 
@@ -47,8 +40,6 @@ export function usePrefsAutosave<P>(options: {
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const spinnerTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const fadeRef = useRef<Record<string, ReturnType<typeof setTimeout>>>({})
-  // Reassigned every render; invoked indirectly via timers so it always sees
-  // the freshest closure.
   const flushRef = useRef<() => void>(() => {})
 
   const scheduleFlush = useCallback(() => {
@@ -80,9 +71,6 @@ export function usePrefsAutosave<P>(options: {
       savingVersionRef.current[f] = versionRef.current[f] ?? 0
     })
 
-    // Reveal the spinner only if the request is still running after a short
-    // grace period — fast saves never flicker one. A field mid-resave keeps its
-    // check-in-middle.
     if (spinnerTimerRef.current) clearTimeout(spinnerTimerRef.current)
     spinnerTimerRef.current = setTimeout(() => {
       fields.forEach((f) => {
@@ -98,8 +86,6 @@ export function usePrefsAutosave<P>(options: {
         () => {
           if (spinnerTimerRef.current) clearTimeout(spinnerTimerRef.current)
           fields.forEach((f) => {
-            // Did the user keep editing this field while the request was in
-            // flight? If so, keep spinning but flash the check in the middle.
             const settled = (versionRef.current[f] ?? 0) === savingVersionRef.current[f]
             if (settled) {
               apply(f, 'saved')

--- a/web-client/src/usePrefsAutosave.ts
+++ b/web-client/src/usePrefsAutosave.ts
@@ -1,0 +1,135 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type { SaveStatus } from './components/SaveIndicator'
+
+// How long to wait after the last keystroke before persisting.
+const SAVE_DELAY_MS = 800
+// How long the green check lingers (matches the fade-out animation) before
+// the indicator clears.
+const CHECKMARK_MS = 600
+
+// Drives debounced autosave for a set of named fields that share a single
+// payload (here: the whole taste-preferences object). Each field gets its own
+// status so the spinner / checkmark can be rendered next to the input the user
+// is actually editing, even though one request persists everything at once.
+export function usePrefsAutosave<P>(options: {
+  save: (payload: P) => Promise<void>
+  onError: (error: unknown) => void
+  delay?: number
+  checkmarkMs?: number
+}) {
+  const { delay = SAVE_DELAY_MS, checkmarkMs = CHECKMARK_MS } = options
+  // Keep the latest callbacks in refs so the timer-driven logic never closes
+  // over a stale version.
+  const saveRef = useRef(options.save)
+  const onErrorRef = useRef(options.onError)
+
+  const [statuses, setStatuses] = useState<Record<string, SaveStatus>>({})
+  const statusesRef = useRef(statuses)
+  const apply = useCallback((field: string, status: SaveStatus) => {
+    const next = { ...statusesRef.current, [field]: status }
+    statusesRef.current = next
+    setStatuses(next)
+  }, [])
+
+  const payloadRef = useRef<P | null>(null)
+  const versionRef = useRef<Record<string, number>>({})
+  const savingVersionRef = useRef<Record<string, number>>({})
+  const dirtyRef = useRef<Set<string>>(new Set())
+  const inFlightRef = useRef(false)
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const fadeRef = useRef<Record<string, ReturnType<typeof setTimeout>>>({})
+  // Reassigned every render; invoked indirectly via timers so it always sees
+  // the freshest closure.
+  const flushRef = useRef<() => void>(() => {})
+
+  const scheduleFlush = useCallback(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+    debounceRef.current = setTimeout(() => {
+      debounceRef.current = null
+      flushRef.current()
+    }, delay)
+  }, [delay])
+
+  const scheduleFade = useCallback(
+    (field: string) => {
+      if (fadeRef.current[field]) clearTimeout(fadeRef.current[field])
+      fadeRef.current[field] = setTimeout(() => {
+        // Only clear if it is still showing the check (no new edit arrived).
+        if (statusesRef.current[field] === 'saved') apply(field, 'idle')
+      }, checkmarkMs)
+    },
+    [apply, checkmarkMs],
+  )
+
+  const flush = () => {
+    // A request is already running — it reschedules itself on settle.
+    if (inFlightRef.current || dirtyRef.current.size === 0) return
+
+    const fields = dirtyRef.current
+    dirtyRef.current = new Set()
+    fields.forEach((f) => {
+      savingVersionRef.current[f] = versionRef.current[f] ?? 0
+    })
+    const payload = payloadRef.current as P
+
+    inFlightRef.current = true
+    saveRef.current(payload)
+      .then(
+        () => {
+          fields.forEach((f) => {
+            // Did the user keep editing this field while the request was in
+            // flight? If so, keep spinning but flash the check in the middle.
+            const settled = (versionRef.current[f] ?? 0) === savingVersionRef.current[f]
+            if (settled) {
+              apply(f, 'saved')
+              scheduleFade(f)
+            } else {
+              apply(f, 'resaving')
+            }
+          })
+        },
+        (err: unknown) => {
+          // Drop the spinner and surface the error; the value stays in the
+          // input, so the next keystroke retries it (no auto-retry loop).
+          fields.forEach((f) => apply(f, 'idle'))
+          onErrorRef.current(err)
+        },
+      )
+      .finally(() => {
+        inFlightRef.current = false
+        // Edits arrived while we were saving and the user has since stopped —
+        // persist them.
+        if (dirtyRef.current.size > 0) scheduleFlush()
+      })
+  }
+
+  // Call on every edit of `field`, passing the full latest payload.
+  const notifyEdit = useCallback(
+    (field: string, payload: P) => {
+      payloadRef.current = payload
+      versionRef.current[field] = (versionRef.current[field] ?? 0) + 1
+      dirtyRef.current.add(field)
+      if (statusesRef.current[field] !== 'resaving') apply(field, 'saving')
+      scheduleFlush()
+    },
+    [apply, scheduleFlush],
+  )
+
+  // Point the timer-driven closures at the latest render's values. Runs after
+  // every commit; writing refs here (not during render) keeps react-hooks happy.
+  useEffect(() => {
+    saveRef.current = options.save
+    onErrorRef.current = options.onError
+    flushRef.current = flush
+  })
+
+  useEffect(
+    () => () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current)
+      Object.values(fadeRef.current).forEach(clearTimeout)
+    },
+    [],
+  )
+
+  return { statuses, notifyEdit }
+}

--- a/web-client/src/usePrefsAutosave.ts
+++ b/web-client/src/usePrefsAutosave.ts
@@ -2,10 +2,13 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import type { SaveStatus } from './components/SaveIndicator'
 
 // How long to wait after the last keystroke before persisting.
-const SAVE_DELAY_MS = 800
-// How long the green check lingers (matches the fade-out animation) before
-// the indicator clears.
-const CHECKMARK_MS = 600
+const SAVE_DELAY_MS = 400
+// How long a request may run before we bother showing the spinner — fast saves
+// finish within this window and never flicker one.
+const SPINNER_DELAY_MS = 300
+// How long the green check lingers (it holds, then fades — matches the
+// fade-out animation) before the indicator clears.
+const CHECKMARK_MS = 1500
 
 // Drives debounced autosave for a set of named fields that share a single
 // payload (here: the whole taste-preferences object). Each field gets its own
@@ -15,9 +18,14 @@ export function usePrefsAutosave<P>(options: {
   save: (payload: P) => Promise<void>
   onError: (error: unknown) => void
   delay?: number
+  spinnerDelay?: number
   checkmarkMs?: number
 }) {
-  const { delay = SAVE_DELAY_MS, checkmarkMs = CHECKMARK_MS } = options
+  const {
+    delay = SAVE_DELAY_MS,
+    spinnerDelay = SPINNER_DELAY_MS,
+    checkmarkMs = CHECKMARK_MS,
+  } = options
   // Keep the latest callbacks in refs so the timer-driven logic never closes
   // over a stale version.
   const saveRef = useRef(options.save)
@@ -37,6 +45,7 @@ export function usePrefsAutosave<P>(options: {
   const dirtyRef = useRef<Set<string>>(new Set())
   const inFlightRef = useRef(false)
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const spinnerTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const fadeRef = useRef<Record<string, ReturnType<typeof setTimeout>>>({})
   // Reassigned every render; invoked indirectly via timers so it always sees
   // the freshest closure.
@@ -70,12 +79,24 @@ export function usePrefsAutosave<P>(options: {
     fields.forEach((f) => {
       savingVersionRef.current[f] = versionRef.current[f] ?? 0
     })
+
+    // Reveal the spinner only if the request is still running after a short
+    // grace period — fast saves never flicker one. A field mid-resave keeps its
+    // check-in-middle.
+    if (spinnerTimerRef.current) clearTimeout(spinnerTimerRef.current)
+    spinnerTimerRef.current = setTimeout(() => {
+      fields.forEach((f) => {
+        if (statusesRef.current[f] !== 'resaving') apply(f, 'saving')
+      })
+    }, spinnerDelay)
+
     const payload = payloadRef.current as P
 
     inFlightRef.current = true
     saveRef.current(payload)
       .then(
         () => {
+          if (spinnerTimerRef.current) clearTimeout(spinnerTimerRef.current)
           fields.forEach((f) => {
             // Did the user keep editing this field while the request was in
             // flight? If so, keep spinning but flash the check in the middle.
@@ -89,9 +110,10 @@ export function usePrefsAutosave<P>(options: {
           })
         },
         (err: unknown) => {
-          // Drop the spinner and surface the error; the value stays in the
+          if (spinnerTimerRef.current) clearTimeout(spinnerTimerRef.current)
+          // Surface a warning on the affected fields; the value stays in the
           // input, so the next keystroke retries it (no auto-retry loop).
-          fields.forEach((f) => apply(f, 'idle'))
+          fields.forEach((f) => apply(f, 'error'))
           onErrorRef.current(err)
         },
       )
@@ -109,7 +131,13 @@ export function usePrefsAutosave<P>(options: {
       payloadRef.current = payload
       versionRef.current[field] = (versionRef.current[field] ?? 0) + 1
       dirtyRef.current.add(field)
-      if (statusesRef.current[field] !== 'resaving') apply(field, 'saving')
+      // Resuming typing clears a finished check / warning right away; no spinner
+      // is shown until the request is actually sent.
+      const current = statusesRef.current[field]
+      if (current === 'saved' || current === 'error') {
+        if (fadeRef.current[field]) clearTimeout(fadeRef.current[field])
+        apply(field, 'idle')
+      }
       scheduleFlush()
     },
     [apply, scheduleFlush],
@@ -126,6 +154,7 @@ export function usePrefsAutosave<P>(options: {
   useEffect(
     () => () => {
       if (debounceRef.current) clearTimeout(debounceRef.current)
+      if (spinnerTimerRef.current) clearTimeout(spinnerTimerRef.current)
       Object.values(fadeRef.current).forEach(clearTimeout)
     },
     [],

--- a/web-client/src/usePrefsAutosave.ts
+++ b/web-client/src/usePrefsAutosave.ts
@@ -10,7 +10,7 @@ const SPINNER_DELAY_MS = 300
 const CHECKMARK_MS = 1500
 
 export function usePrefsAutosave<P>(options: {
-  save: (payload: P) => Promise<void>
+  save: (payload: P, keepalive?: boolean) => Promise<void>
   onError: (error: unknown) => void
   delay?: number
   spinnerDelay?: number
@@ -111,6 +111,16 @@ export function usePrefsAutosave<P>(options: {
       })
   }
 
+  const savePendingEditsNow = useCallback(() => {
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current)
+      debounceRef.current = null
+    }
+    if (inFlightRef.current || dirtyRef.current.size === 0) return
+    dirtyRef.current = new Set()
+    saveRef.current(payloadRef.current as P, true).catch((err) => onErrorRef.current(err))
+  }, [])
+
   // Call on every edit of `field`, passing the full latest payload.
   const notifyEdit = useCallback(
     (field: string, payload: P) => {
@@ -137,9 +147,18 @@ export function usePrefsAutosave<P>(options: {
     flushRef.current = flush
   })
 
+	// Save pending edits when the user navigates
+  useEffect(() => {
+    const onPageHide = () => savePendingEditsNow()
+    window.addEventListener('pagehide', onPageHide)
+    return () => {
+      window.removeEventListener('pagehide', onPageHide)
+      savePendingEditsNow()
+    }
+  }, [savePendingEditsNow])
+
   useEffect(
     () => () => {
-      if (debounceRef.current) clearTimeout(debounceRef.current)
       if (spinnerTimerRef.current) clearTimeout(spinnerTimerRef.current)
       Object.values(fadeRef.current).forEach(clearTimeout)
     },

--- a/web-client/tests/pages/ProfilePage.test.tsx
+++ b/web-client/tests/pages/ProfilePage.test.tsx
@@ -1,347 +1,326 @@
-import { Route, Routes } from 'react-router-dom'
-import { act, screen, waitFor, within } from '@testing-library/react'
+import {Route, Routes} from 'react-router-dom'
+import {act, screen, waitFor, within} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { afterEach, beforeEach, vi } from 'vitest'
-import { ProfilePage } from '../../src/pages/ProfilePage'
-import { jsonResponse, renderWithProviders } from '../utils'
+import {afterEach, beforeEach, vi} from 'vitest'
+import {ProfilePage} from '../../src/pages/ProfilePage'
+import {jsonResponse, renderWithProviders} from '../utils'
 
 const fetchMock = vi.fn<typeof fetch>()
 
 beforeEach(() => {
-  vi.stubGlobal('fetch', fetchMock)
+	vi.stubGlobal('fetch', fetchMock)
 })
 afterEach(() => {
-  fetchMock.mockReset()
-  vi.unstubAllGlobals()
+	fetchMock.mockReset()
+	vi.unstubAllGlobals()
 })
 
 function render() {
-  renderWithProviders(
-    <Routes>
-      <Route path="/profile" element={<ProfilePage />} />
-      <Route path="/login" element={<div>login page</div>} />
-    </Routes>,
-    { route: '/profile', token: { value: 'tkn', username: 'alice' } },
-  )
+	renderWithProviders(
+		<Routes>
+			<Route path="/profile" element={<ProfilePage/>}/>
+			<Route path="/login" element={<div>login page</div>}/>
+		</Routes>,
+		{route: '/profile', token: {value: 'tkn', username: 'alice'}},
+	)
 }
 
 function defaultProfileFetch(body: { username: string }) {
-  fetchMock.mockImplementation((_input, init) => {
-    const method = init?.method ?? 'GET'
-    if (method === 'GET') {
-      return Promise.resolve(jsonResponse({ username: body.username, preferences: {} }))
-    }
-    return Promise.resolve(jsonResponse({}))
-  })
+	fetchMock.mockImplementation((_input, init) => {
+		const method = init?.method ?? 'GET'
+		if (method === 'GET') {
+			return Promise.resolve(jsonResponse({username: body.username, preferences: {}}))
+		}
+		return Promise.resolve(jsonResponse({}))
+	})
 }
 
 describe('ProfilePage', () => {
-  it('blocks the password update when the two fields disagree (no PUT issued)', async () => {
-    defaultProfileFetch({ username: 'alice' })
-    const user = userEvent.setup()
-    render()
-    await user.type(screen.getByLabelText('New password'), 'aaa')
-    await user.type(screen.getByLabelText('Repeat new password'), 'bbb')
+	it('blocks the password update when the two fields disagree (no PUT issued)', async () => {
+		defaultProfileFetch({username: 'alice'})
+		const user = userEvent.setup()
+		render()
+		await user.type(screen.getByLabelText('New password'), 'aaa')
+		await user.type(screen.getByLabelText('Repeat new password'), 'bbb')
 
-    await user.click(screen.getByRole('button', { name: 'Update password' }))
+		await user.click(screen.getByRole('button', {name: 'Update password'}))
 
-    expect(await screen.findByText('Passwords do not match')).toBeInTheDocument()
-    expect(fetchMock.mock.calls.filter(([, init]) => init?.method === 'PUT')).toHaveLength(0)
-  })
+		expect(await screen.findByText('Passwords do not match')).toBeInTheDocument()
+		expect(fetchMock.mock.calls.filter(([, init]) => init?.method === 'PUT')).toHaveLength(0)
+	})
 
-  it('shows "Username already taken" on a 409 from the username PUT', async () => {
-    fetchMock.mockImplementation((_input, init) => {
-      const method = init?.method ?? 'GET'
-      if (method === 'GET') {
-        return Promise.resolve(jsonResponse({ username: 'alice', preferences: {} }))
-      }
-      return Promise.resolve(
-        jsonResponse({ message: 'Username already taken' }, { status: 409 }),
-      )
-    })
-    const user = userEvent.setup()
-    render()
-    const usernameField = await screen.findByLabelText('New username')
-    await user.clear(usernameField)
-    await user.type(usernameField, 'bob')
+	it('shows "Username already taken" on a 409 from the username PUT', async () => {
+		fetchMock.mockImplementation((_input, init) => {
+			const method = init?.method ?? 'GET'
+			if (method === 'GET') {
+				return Promise.resolve(jsonResponse({username: 'alice', preferences: {}}))
+			}
+			return Promise.resolve(
+				jsonResponse({message: 'Username already taken'}, {status: 409}),
+			)
+		})
+		const user = userEvent.setup()
+		render()
+		const usernameField = await screen.findByLabelText('New username')
+		await user.clear(usernameField)
+		await user.type(usernameField, 'bob')
 
-    await user.click(screen.getByRole('button', { name: 'Update username' }))
+		await user.click(screen.getByRole('button', {name: 'Update username'}))
 
-    expect(await screen.findByText('Username already taken')).toBeInTheDocument()
-  })
+		expect(await screen.findByText('Username already taken')).toBeInTheDocument()
+	})
 
-  // The taste-preferences card has no submit button; saving happens
-  // automatically a short while after the user stops typing.
-  describe('taste-preferences autosave', () => {
-    // the indicator that is currently doing something (everything else is idle)
-    const activeIndicator = () =>
-      document.querySelector('[data-status]:not([data-status="idle"])')
-    const status = () => activeIndicator()?.getAttribute('data-status') ?? 'idle'
+	describe('taste-preferences autosave', () => {
+		const status = () => document.querySelector('[data-status]:not([data-status="idle"])')
+			?.getAttribute('data-status') ?? 'idle'
 
-    const putCalls = () =>
-      fetchMock.mock.calls.filter(([, init]) => init?.method === 'PUT')
-    const lastPutBody = () => {
-      const calls = putCalls()
-      return JSON.parse(calls[calls.length - 1][1]!.body as string)
-    }
+		const putCalls = () =>
+			fetchMock.mock.calls.filter(([, init]) => init?.method === 'PUT')
+		const lastPutBody = () => {
+			const calls = putCalls()
+			return JSON.parse(calls[calls.length - 1][1]!.body as string)
+		}
 
-    // render, then let the initial GET /profile resolve before interacting so
-    // it can't clobber what the user types
-    async function renderSettled() {
-      render()
-      await act(async () => {
-        for (let i = 0; i < 5; i++) await Promise.resolve()
-      })
-    }
+		// render, then let the initial GET /profile resolve
+		async function renderSettled() {
+			render()
+			await act(async () => {
+				for (let i = 0; i < 5; i++) await Promise.resolve()
+			})
+		}
 
-    // resolve a deferred fetch and flush the state updates it triggers
-    async function resolveAndFlush(fn: () => void) {
-      await act(async () => {
-        fn()
-        for (let i = 0; i < 5; i++) await Promise.resolve()
-      })
-    }
+		// resolve a deferred fetch and resolve
+		async function resolveAndFlush(fn: () => void) {
+			await act(async () => {
+				fn()
+				// repeat a few times to make sure cascading updates are done
+				for (let i = 0; i < 5; i++) await Promise.resolve()
+			})
+		}
 
-    it('has no "Update taste preferences" button', async () => {
-      defaultProfileFetch({ username: 'alice' })
-      await renderSettled()
-      expect(
-        screen.queryByRole('button', { name: 'Update taste preferences' }),
-      ).toBeNull()
-    })
+		it('shows no spinner while typing, spins only once the request is sent, then flashes a check that fades out', async () => {
+			const pending: Array<() => void> = []
+			fetchMock.mockImplementation((_input, init) => {
+				const method = init?.method ?? 'GET'
+				if (method === 'GET') {
+					return Promise.resolve(jsonResponse({username: 'alice', preferences: {}}))
+				}
+				return new Promise<Response>((resolve) => {
+					pending.push(() => resolve(jsonResponse({})))
+				})
+			})
+			const user = userEvent.setup()
+			await renderSettled()
 
-    it('shows no spinner while typing, spins only once the request is sent, then flashes a check that fades out', async () => {
-      // PUTs resolve only when we say so, so we can observe the spinner appear
-      // exactly when the request goes out (not while typing)
-      const pending: Array<() => void> = []
-      fetchMock.mockImplementation((_input, init) => {
-        const method = init?.method ?? 'GET'
-        if (method === 'GET') {
-          return Promise.resolve(jsonResponse({ username: 'alice', preferences: {} }))
-        }
-        return new Promise<Response>((resolve) => {
-          pending.push(() => resolve(jsonResponse({})))
-        })
-      })
-      const user = userEvent.setup()
-      await renderSettled()
+			await user.type(screen.getByLabelText('About me'), '  spicy food  ')
 
-      await user.type(screen.getByLabelText('About me'), '  spicy food  ')
+			// while typing: no spinner yet and nothing has been sent
+			expect(status()).toBe('idle')
+			expect(putCalls()).toHaveLength(0)
 
-      // while typing: no spinner yet and nothing has been sent
-      expect(status()).toBe('idle')
-      expect(putCalls()).toHaveLength(0)
+			// once the user pauses, the request goes out with the trimmed value
+			await waitFor(() => expect(pending).toHaveLength(1), {timeout: 2000})
+			expect(lastPutBody().preferences.aboutMe).toEqual(['spicy food'])
+			// the spinner only appears once the request outlasts its grace period
+			await waitFor(() => expect(status()).toBe('saving'), {timeout: 2000})
 
-      // once the user pauses, the request goes out with the trimmed value
-      await waitFor(() => expect(pending).toHaveLength(1), { timeout: 2000 })
-      expect(lastPutBody().preferences.aboutMe).toEqual(['spicy food'])
-      // the spinner only appears once the request outlasts its grace period
-      await waitFor(() => expect(status()).toBe('saving'), { timeout: 2000 })
+			// the green check appears...
+			await resolveAndFlush(pending[0])
+			await waitFor(() => expect(status()).toBe('saved'))
+			// ...lingers, then clears itself
+			await waitFor(() => expect(document.querySelector('[data-status]:not([data-status="idle"])')).toBeNull(), {timeout: 3000})
+		})
 
-      // the green check appears...
-      await resolveAndFlush(pending[0])
-      await waitFor(() => expect(status()).toBe('saved'))
-      // ...lingers, then clears itself
-      await waitFor(() => expect(activeIndicator()).toBeNull(), { timeout: 3000 })
-    })
+		it('never flashes the spinner for a save that finishes within the grace period', async () => {
+			// the PUT resolves immediately — well inside the spinner grace period
+			defaultProfileFetch({username: 'alice'})
+			const user = userEvent.setup()
+			await renderSettled()
 
-    it('never flashes the spinner for a save that finishes within the grace period', async () => {
-      // the PUT resolves immediately — well inside the spinner grace period
-      defaultProfileFetch({ username: 'alice' })
-      const user = userEvent.setup()
-      await renderSettled()
+			// record every status the indicator passes through
+			const seen = new Set<string>()
+			const observer = new MutationObserver((mutations) => {
+				for (const m of mutations) {
+					const value = (m.target as Element).getAttribute?.('data-status')
+					if (value) seen.add(value)
+				}
+			})
+			observer.observe(document.body, {
+				subtree: true,
+				attributes: true,
+				attributeFilter: ['data-status'],
+			})
 
-      // record every status the indicator passes through
-      const seen = new Set<string>()
-      const observer = new MutationObserver((mutations) => {
-        for (const m of mutations) {
-          const value = (m.target as Element).getAttribute?.('data-status')
-          if (value) seen.add(value)
-        }
-      })
-      observer.observe(document.body, {
-        subtree: true,
-        attributes: true,
-        attributeFilter: ['data-status'],
-      })
+			await user.type(screen.getByLabelText('About me'), 'fast')
+			await waitFor(() => expect(putCalls()).toHaveLength(1), {timeout: 2000})
+			await waitFor(() => expect(seen.has('saved')).toBe(true), {timeout: 2000})
+			observer.disconnect()
 
-      await user.type(screen.getByLabelText('About me'), 'fast')
-      await waitFor(() => expect(putCalls()).toHaveLength(1), { timeout: 2000 })
-      await waitFor(() => expect(seen.has('saved')).toBe(true), { timeout: 2000 })
-      observer.disconnect()
+			// it went straight from idle to the check — no spinner in between
+			expect(seen.has('saving')).toBe(false)
+		})
 
-      // it went straight from idle to the check — no spinner in between
-      expect(seen.has('saving')).toBe(false)
-    })
+		it('debounces a burst of keystrokes into a single request', async () => {
+			defaultProfileFetch({username: 'alice'})
+			const user = userEvent.setup()
+			await renderSettled()
 
-    it('debounces a burst of keystrokes into a single request', async () => {
-      defaultProfileFetch({ username: 'alice' })
-      const user = userEvent.setup()
-      await renderSettled()
+			const aboutMe = screen.getByLabelText('About me')
+			await user.type(aboutMe, 'ab')
+			await user.type(aboutMe, 'cd')
 
-      // two bursts typed back-to-back (well within the debounce window)
-      const aboutMe = screen.getByLabelText('About me')
-      await user.type(aboutMe, 'ab')
-      await user.type(aboutMe, 'cd')
+			await waitFor(() => expect(putCalls()).toHaveLength(1), {timeout: 2000})
+			expect(lastPutBody().preferences.aboutMe).toEqual(['abcd'])
+		})
 
-      await waitFor(() => expect(putCalls()).toHaveLength(1), { timeout: 2000 })
-      expect(lastPutBody().preferences.aboutMe).toEqual(['abcd'])
-    })
+		it('strips empty diet/allergy entries before sending', async () => {
+			defaultProfileFetch({username: 'alice'})
+			const user = userEvent.setup()
+			await renderSettled()
 
-    it('strips empty diet/allergy entries before sending', async () => {
-      defaultProfileFetch({ username: 'alice' })
-      const user = userEvent.setup()
-      await renderSettled()
+			// fill only the first allergy slot; the lone diet slot stays empty
+			const allergyInputs = screen.getAllByPlaceholderText(/e\.g\. (peanuts|shellfish)/i)
+			await user.type(allergyInputs[0], 'peanuts')
 
-      // fill only the first allergy slot; the lone diet slot stays empty
-      const allergyInputs = screen.getAllByPlaceholderText(/e\.g\. (peanuts|shellfish)/i)
-      await user.type(allergyInputs[0], 'peanuts')
+			await waitFor(() => expect(putCalls()).toHaveLength(1), {timeout: 2000})
+			const body = lastPutBody()
+			expect(body.preferences.allergies).toEqual(['peanuts'])
+			expect(body.preferences.diet).toEqual([])
+		})
 
-      await waitFor(() => expect(putCalls()).toHaveLength(1), { timeout: 2000 })
-      const body = lastPutBody()
-      expect(body.preferences.allergies).toEqual(['peanuts'])
-      expect(body.preferences.diet).toEqual([])
-    })
+		it('keeps spinning with a check in the middle when the user types during the save, then saves again', async () => {
+			// PUTs resolve only when we say so, so we can type mid-flight
+			const pending: Array<() => void> = []
+			fetchMock.mockImplementation((_input, init) => {
+				const method = init?.method ?? 'GET'
+				if (method === 'GET') {
+					return Promise.resolve(jsonResponse({username: 'alice', preferences: {}}))
+				}
+				return new Promise<Response>((resolve) => {
+					pending.push(() => resolve(jsonResponse({})))
+				})
+			})
+			const user = userEvent.setup()
+			await renderSettled()
 
-    it('keeps spinning with a check in the middle when the user types during the save, then saves again', async () => {
-      // PUTs resolve only when we say so, so we can type mid-flight
-      const pending: Array<() => void> = []
-      fetchMock.mockImplementation((_input, init) => {
-        const method = init?.method ?? 'GET'
-        if (method === 'GET') {
-          return Promise.resolve(jsonResponse({ username: 'alice', preferences: {} }))
-        }
-        return new Promise<Response>((resolve) => {
-          pending.push(() => resolve(jsonResponse({})))
-        })
-      })
-      const user = userEvent.setup()
-      await renderSettled()
+			const aboutMe = screen.getByLabelText('About me')
+			await user.type(aboutMe, 'a')
+			// first request fires after the debounce and is now in flight
+			await waitFor(() => expect(pending).toHaveLength(1), {timeout: 2000})
+			await waitFor(() => expect(status()).toBe('saving'), {timeout: 2000})
 
-      const aboutMe = screen.getByLabelText('About me')
-      await user.type(aboutMe, 'a')
-      // first request fires after the debounce and is now in flight
-      await waitFor(() => expect(pending).toHaveLength(1), { timeout: 2000 })
-      await waitFor(() => expect(status()).toBe('saving'), { timeout: 2000 })
+			// user keeps typing before the server answers
+			await user.type(aboutMe, 'b')
 
-      // user keeps typing before the server answers
-      await user.type(aboutMe, 'b')
+			// first request succeeds → check shown in the middle, but still spinning
+			await resolveAndFlush(pending[0])
+			expect(status()).toBe('resaving')
 
-      // first request succeeds → check shown in the middle, but still spinning
-      await resolveAndFlush(pending[0])
-      expect(status()).toBe('resaving')
+			// having stopped typing, the latest value is saved again
+			await waitFor(() => expect(pending).toHaveLength(2), {timeout: 2000})
+			await resolveAndFlush(pending[1])
+			expect(lastPutBody().preferences.aboutMe).toEqual(['ab'])
+			await waitFor(() => expect(status()).toBe('saved'))
+		})
 
-      // having stopped typing, the latest value is saved again
-      await waitFor(() => expect(pending).toHaveLength(2), { timeout: 2000 })
-      await resolveAndFlush(pending[1])
-      expect(lastPutBody().preferences.aboutMe).toEqual(['ab'])
-      await waitFor(() => expect(status()).toBe('saved'))
-    })
+		it('shows a warning sign and message when the save fails, and clears it on the next edit', async () => {
+			fetchMock.mockImplementation((_input, init) => {
+				const method = init?.method ?? 'GET'
+				if (method === 'GET') {
+					return Promise.resolve(jsonResponse({username: 'alice', preferences: {}}))
+				}
+				return Promise.resolve(jsonResponse({message: 'Server on fire'}, {status: 500}))
+			})
+			const user = userEvent.setup()
+			await renderSettled()
 
-    it('shows a warning sign and message when the save fails, and clears it on the next edit', async () => {
-      fetchMock.mockImplementation((_input, init) => {
-        const method = init?.method ?? 'GET'
-        if (method === 'GET') {
-          return Promise.resolve(jsonResponse({ username: 'alice', preferences: {} }))
-        }
-        return Promise.resolve(jsonResponse({ message: 'Server on fire' }, { status: 500 }))
-      })
-      const user = userEvent.setup()
-      await renderSettled()
+			const aboutMe = screen.getByLabelText('About me')
+			await user.type(aboutMe, 'spicy')
 
-      const aboutMe = screen.getByLabelText('About me')
-      await user.type(aboutMe, 'spicy')
+			await waitFor(() => expect(screen.getByText('Server on fire')).toBeInTheDocument(), {
+				timeout: 2000,
+			})
+			expect(status()).toBe('error')
+			expect(screen.getByTestId('save-error')).toBeInTheDocument()
 
-      // the message is surfaced and a warning sign sits beside the field
-      await waitFor(() => expect(screen.getByText('Server on fire')).toBeInTheDocument(), {
-        timeout: 2000,
-      })
-      expect(status()).toBe('error')
-      expect(screen.getByTestId('save-error')).toBeInTheDocument()
+			// resuming typing clears the warning
+			await user.type(aboutMe, '!')
+			expect(status()).toBe('idle')
+		})
 
-      // resuming typing clears the warning (no spinner until the next send)
-      await user.type(aboutMe, '!')
-      expect(status()).toBe('idle')
-    })
+		it('reports an unreachable server in plain language', async () => {
+			fetchMock.mockImplementation((_input, init) => {
+				const method = init?.method ?? 'GET'
+				if (method === 'GET') {
+					return Promise.resolve(jsonResponse({username: 'alice', preferences: {}}))
+				}
+				return Promise.reject(new TypeError('Failed to fetch'))
+			})
+			const user = userEvent.setup()
+			await renderSettled()
 
-    it('reports an unreachable server in plain language', async () => {
-      fetchMock.mockImplementation((_input, init) => {
-        const method = init?.method ?? 'GET'
-        if (method === 'GET') {
-          return Promise.resolve(jsonResponse({ username: 'alice', preferences: {} }))
-        }
-        // what fetch throws when the server is down / connection refused
-        return Promise.reject(new TypeError('Failed to fetch'))
-      })
-      const user = userEvent.setup()
-      await renderSettled()
+			await user.type(screen.getByLabelText('About me'), 'spicy')
 
-      await user.type(screen.getByLabelText('About me'), 'spicy')
+			await waitFor(
+				() => expect(screen.getByText("Couldn't reach the server")).toBeInTheDocument(),
+				{timeout: 2000},
+			)
+			expect(screen.getByTestId('save-error')).toBeInTheDocument()
+		})
 
-      await waitFor(
-        () => expect(screen.getByText("Couldn't reach the server")).toBeInTheDocument(),
-        { timeout: 2000 },
-      )
-      expect(screen.getByTestId('save-error')).toBeInTheDocument()
-    })
+		// the trash button for a row
+		const trashIn = (input: HTMLElement) =>
+			within(input.closest('.relative')!.parentElement as HTMLElement).getByRole('button')
 
-    // the trash button for a row
-    const trashIn = (input: HTMLElement) =>
-      within(input.closest('.relative')!.parentElement as HTMLElement).getByRole('button')
+		it('disables a row while its deletion is in flight and only drops it once the server confirms', async () => {
+			const pending: Array<() => void> = []
+			fetchMock.mockImplementation((_input, init) => {
+				const method = init?.method ?? 'GET'
+				if (method === 'GET') {
+					return Promise.resolve(
+						jsonResponse({username: 'alice', preferences: {diet: ['vegan', 'keto']}}),
+					)
+				}
+				return new Promise<Response>((resolve) => {
+					pending.push(() => resolve(jsonResponse({})))
+				})
+			})
+			const user = userEvent.setup()
+			await renderSettled()
 
-    it('disables a row while its deletion is in flight and only drops it once the server confirms', async () => {
-      const pending: Array<() => void> = []
-      fetchMock.mockImplementation((_input, init) => {
-        const method = init?.method ?? 'GET'
-        if (method === 'GET') {
-          return Promise.resolve(
-            jsonResponse({ username: 'alice', preferences: { diet: ['vegan', 'keto'] } }),
-          )
-        }
-        return new Promise<Response>((resolve) => {
-          pending.push(() => resolve(jsonResponse({})))
-        })
-      })
-      const user = userEvent.setup()
-      await renderSettled()
+			const vegan = screen.getByDisplayValue('vegan')
+			await user.click(trashIn(vegan))
 
-      const vegan = screen.getByDisplayValue('vegan')
-      await user.click(trashIn(vegan))
+			expect(vegan).toBeDisabled()
+			expect(trashIn(vegan)).toBeDisabled()
+			await waitFor(() => expect(pending).toHaveLength(1), {timeout: 2000})
+			expect(lastPutBody().preferences.diet).toEqual(['keto'])
 
-      // the row stays on screen but disabled until the server answers
-      expect(vegan).toBeDisabled()
-      expect(trashIn(vegan)).toBeDisabled()
-      // the PUT persists the list without the deleted row
-      await waitFor(() => expect(pending).toHaveLength(1), { timeout: 2000 })
-      expect(lastPutBody().preferences.diet).toEqual(['keto'])
+			await resolveAndFlush(pending[0])
+			expect(screen.queryByDisplayValue('vegan')).toBeNull()
+			expect(screen.getByDisplayValue('keto')).toBeInTheDocument()
+		})
 
-      // only once it succeeds does the row leave the list
-      await resolveAndFlush(pending[0])
-      expect(screen.queryByDisplayValue('vegan')).toBeNull()
-      expect(screen.getByDisplayValue('keto')).toBeInTheDocument()
-    })
+		it('brings a row back and shows the error when its deletion fails', async () => {
+			fetchMock.mockImplementation((_input, init) => {
+				const method = init?.method ?? 'GET'
+				if (method === 'GET') {
+					return Promise.resolve(
+						jsonResponse({username: 'alice', preferences: {diet: ['vegan', 'keto']}}),
+					)
+				}
+				return Promise.resolve(jsonResponse({message: 'Nope'}, {status: 500}))
+			})
+			const user = userEvent.setup()
+			await renderSettled()
 
-    it('brings a row back and shows the error when its deletion fails', async () => {
-      fetchMock.mockImplementation((_input, init) => {
-        const method = init?.method ?? 'GET'
-        if (method === 'GET') {
-          return Promise.resolve(
-            jsonResponse({ username: 'alice', preferences: { diet: ['vegan', 'keto'] } }),
-          )
-        }
-        return Promise.resolve(jsonResponse({ message: 'Nope' }, { status: 500 }))
-      })
-      const user = userEvent.setup()
-      await renderSettled()
+			const vegan = screen.getByDisplayValue('vegan')
+			await user.click(trashIn(vegan))
 
-      const vegan = screen.getByDisplayValue('vegan')
-      await user.click(trashIn(vegan))
-
-      await waitFor(() => expect(screen.getByText('Nope')).toBeInTheDocument(), { timeout: 2000 })
-      // the row is still there and interactive again
-      expect(vegan).toBeInTheDocument()
-      expect(vegan).not.toBeDisabled()
-      expect(trashIn(vegan)).not.toBeDisabled()
-    })
-  })
+			await waitFor(() => expect(screen.getByText('Nope')).toBeInTheDocument(), {timeout: 2000})
+			expect(vegan).toBeInTheDocument()
+			expect(vegan).not.toBeDisabled()
+			expect(trashIn(vegan)).not.toBeDisabled()
+		})
+	})
 })

--- a/web-client/tests/pages/ProfilePage.test.tsx
+++ b/web-client/tests/pages/ProfilePage.test.tsx
@@ -1,5 +1,5 @@
 import { Route, Routes } from 'react-router-dom'
-import { screen, waitFor } from '@testing-library/react'
+import { act, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, vi } from 'vitest'
 import { ProfilePage } from '../../src/pages/ProfilePage'
@@ -49,27 +49,6 @@ describe('ProfilePage', () => {
     expect(fetchMock.mock.calls.filter(([, init]) => init?.method === 'PUT')).toHaveLength(0)
   })
 
-  it('strips empty diet/allergy entries before sending the preferences PUT', async () => {
-    defaultProfileFetch({ username: 'alice' })
-    const user = userEvent.setup()
-    render()
-    // fill only the first allergy slot; the second stays empty
-    const allergyInputs = await screen.findAllByPlaceholderText(/e\.g\. (peanuts|shellfish)/i)
-    await user.type(allergyInputs[0], 'peanuts')
-
-    await user.click(screen.getByRole('button', { name: 'Update taste preferences' }))
-
-    await waitFor(() => {
-      expect(
-        fetchMock.mock.calls.find(([, init]) => init?.method === 'PUT'),
-      ).toBeDefined()
-    })
-    const putCall = fetchMock.mock.calls.find(([, init]) => init?.method === 'PUT')!
-    const body = JSON.parse(putCall[1]!.body as string)
-    expect(body.preferences.allergies).toEqual(['peanuts'])
-    expect(body.preferences.diet).toEqual([])
-  })
-
   it('shows "Username already taken" on a 409 from the username PUT', async () => {
     fetchMock.mockImplementation((_input, init) => {
       const method = init?.method ?? 'GET'
@@ -89,5 +68,151 @@ describe('ProfilePage', () => {
     await user.click(screen.getByRole('button', { name: 'Update username' }))
 
     expect(await screen.findByText('Username already taken')).toBeInTheDocument()
+  })
+
+  // The taste-preferences card has no submit button; saving happens
+  // automatically a short while after the user stops typing.
+  describe('taste-preferences autosave', () => {
+    // the indicator that is currently doing something (everything else is idle)
+    const activeIndicator = () =>
+      document.querySelector('[data-status]:not([data-status="idle"])')
+    const status = () => activeIndicator()?.getAttribute('data-status') ?? 'idle'
+
+    const putCalls = () =>
+      fetchMock.mock.calls.filter(([, init]) => init?.method === 'PUT')
+    const lastPutBody = () => {
+      const calls = putCalls()
+      return JSON.parse(calls[calls.length - 1][1]!.body as string)
+    }
+
+    // render, then let the initial GET /profile resolve before interacting so
+    // it can't clobber what the user types
+    async function renderSettled() {
+      render()
+      await act(async () => {
+        for (let i = 0; i < 5; i++) await Promise.resolve()
+      })
+    }
+
+    // resolve a deferred fetch and flush the state updates it triggers
+    async function resolveAndFlush(fn: () => void) {
+      await act(async () => {
+        fn()
+        for (let i = 0; i < 5; i++) await Promise.resolve()
+      })
+    }
+
+    it('has no "Update taste preferences" button', async () => {
+      defaultProfileFetch({ username: 'alice' })
+      await renderSettled()
+      expect(
+        screen.queryByRole('button', { name: 'Update taste preferences' }),
+      ).toBeNull()
+    })
+
+    it('shows a spinner while typing, then saves the trimmed value after a pause and flashes a check that fades out', async () => {
+      defaultProfileFetch({ username: 'alice' })
+      const user = userEvent.setup()
+      await renderSettled()
+
+      await user.type(screen.getByLabelText('About me'), '  spicy food  ')
+
+      // spinner is showing immediately and nothing has been sent yet
+      expect(status()).toBe('saving')
+      expect(putCalls()).toHaveLength(0)
+
+      // once the user pauses, the request goes out with the trimmed value
+      await waitFor(() => expect(putCalls()).toHaveLength(1), { timeout: 2000 })
+      expect(lastPutBody().preferences.aboutMe).toEqual(['spicy food'])
+
+      // the green check appears...
+      await waitFor(() => expect(status()).toBe('saved'))
+      // ...and clears itself shortly after
+      await waitFor(() => expect(activeIndicator()).toBeNull(), { timeout: 2000 })
+    })
+
+    it('debounces a burst of keystrokes into a single request', async () => {
+      defaultProfileFetch({ username: 'alice' })
+      const user = userEvent.setup()
+      await renderSettled()
+
+      // two bursts typed back-to-back (well within the debounce window)
+      const aboutMe = screen.getByLabelText('About me')
+      await user.type(aboutMe, 'ab')
+      await user.type(aboutMe, 'cd')
+
+      await waitFor(() => expect(putCalls()).toHaveLength(1), { timeout: 2000 })
+      expect(lastPutBody().preferences.aboutMe).toEqual(['abcd'])
+    })
+
+    it('strips empty diet/allergy entries before sending', async () => {
+      defaultProfileFetch({ username: 'alice' })
+      const user = userEvent.setup()
+      await renderSettled()
+
+      // fill only the first allergy slot; the lone diet slot stays empty
+      const allergyInputs = screen.getAllByPlaceholderText(/e\.g\. (peanuts|shellfish)/i)
+      await user.type(allergyInputs[0], 'peanuts')
+
+      await waitFor(() => expect(putCalls()).toHaveLength(1), { timeout: 2000 })
+      const body = lastPutBody()
+      expect(body.preferences.allergies).toEqual(['peanuts'])
+      expect(body.preferences.diet).toEqual([])
+    })
+
+    it('keeps spinning with a check in the middle when the user types during the save, then saves again', async () => {
+      // PUTs resolve only when we say so, so we can type mid-flight
+      const pending: Array<() => void> = []
+      fetchMock.mockImplementation((_input, init) => {
+        const method = init?.method ?? 'GET'
+        if (method === 'GET') {
+          return Promise.resolve(jsonResponse({ username: 'alice', preferences: {} }))
+        }
+        return new Promise<Response>((resolve) => {
+          pending.push(() => resolve(jsonResponse({})))
+        })
+      })
+      const user = userEvent.setup()
+      await renderSettled()
+
+      const aboutMe = screen.getByLabelText('About me')
+      await user.type(aboutMe, 'a')
+      // first request fires after the debounce and is now in flight
+      await waitFor(() => expect(pending).toHaveLength(1), { timeout: 2000 })
+      expect(status()).toBe('saving')
+
+      // user keeps typing before the server answers
+      await user.type(aboutMe, 'b')
+
+      // first request succeeds → check shown in the middle, but still spinning
+      await resolveAndFlush(pending[0])
+      expect(status()).toBe('resaving')
+
+      // having stopped typing, the latest value is saved again
+      await waitFor(() => expect(pending).toHaveLength(2), { timeout: 2000 })
+      await resolveAndFlush(pending[1])
+      expect(lastPutBody().preferences.aboutMe).toEqual(['ab'])
+      await waitFor(() => expect(status()).toBe('saved'))
+    })
+
+    it('surfaces a server error when the save fails', async () => {
+      fetchMock.mockImplementation((_input, init) => {
+        const method = init?.method ?? 'GET'
+        if (method === 'GET') {
+          return Promise.resolve(jsonResponse({ username: 'alice', preferences: {} }))
+        }
+        return Promise.resolve(jsonResponse({ message: 'Server on fire' }, { status: 500 }))
+      })
+      const user = userEvent.setup()
+      await renderSettled()
+
+      await user.type(screen.getByLabelText('About me'), 'spicy')
+
+      // the error is surfaced and the spinner is gone
+      await waitFor(() => expect(screen.getByText('Server on fire')).toBeInTheDocument(), {
+        timeout: 2000,
+      })
+      expect(activeIndicator()).toBeNull()
+    })
   })
 })

--- a/web-client/tests/pages/ProfilePage.test.tsx
+++ b/web-client/tests/pages/ProfilePage.test.tsx
@@ -1,5 +1,5 @@
 import {Route, Routes} from 'react-router-dom'
-import {act, screen, waitFor, within} from '@testing-library/react'
+import {act, cleanup, screen, waitFor, within} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import {afterEach, beforeEach, vi} from 'vitest'
 import {ProfilePage} from '../../src/pages/ProfilePage'
@@ -266,6 +266,37 @@ describe('ProfilePage', () => {
 				{timeout: 2000},
 			)
 			expect(screen.getByTestId('save-error')).toBeInTheDocument()
+		})
+
+		it('flushes a pending edit on pagehide (reload/tab close)', async () => {
+			defaultProfileFetch({username: 'alice'})
+			const user = userEvent.setup()
+			await renderSettled()
+
+			// type and leave immediately — still inside the debounce, nothing sent
+			await user.type(screen.getByLabelText('About me'), 'last words')
+			expect(putCalls()).toHaveLength(0)
+
+			await resolveAndFlush(() => window.dispatchEvent(new Event('pagehide')))
+
+			expect(putCalls()).toHaveLength(1)
+			expect(lastPutBody().preferences.aboutMe).toEqual(['last words'])
+			// keepalive lets the request outlive the unloading document
+			expect(putCalls()[0][1]?.keepalive).toBe(true)
+		})
+
+		it('flushes a pending edit when the page unmounts (switching pages)', async () => {
+			defaultProfileFetch({username: 'alice'})
+			const user = userEvent.setup()
+			await renderSettled()
+
+			await user.type(screen.getByLabelText('About me'), 'unsaved')
+			expect(putCalls()).toHaveLength(0)
+
+			await resolveAndFlush(() => cleanup())
+
+			expect(putCalls()).toHaveLength(1)
+			expect(lastPutBody().preferences.aboutMe).toEqual(['unsaved'])
 		})
 
 		// the trash button for a row

--- a/web-client/tests/pages/ProfilePage.test.tsx
+++ b/web-client/tests/pages/ProfilePage.test.tsx
@@ -1,5 +1,5 @@
 import { Route, Routes } from 'react-router-dom'
-import { act, screen, waitFor } from '@testing-library/react'
+import { act, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, vi } from 'vitest'
 import { ProfilePage } from '../../src/pages/ProfilePage'
@@ -283,6 +283,65 @@ describe('ProfilePage', () => {
         { timeout: 2000 },
       )
       expect(screen.getByTestId('save-error')).toBeInTheDocument()
+    })
+
+    // the trash button for a row
+    const trashIn = (input: HTMLElement) =>
+      within(input.closest('.relative')!.parentElement as HTMLElement).getByRole('button')
+
+    it('disables a row while its deletion is in flight and only drops it once the server confirms', async () => {
+      const pending: Array<() => void> = []
+      fetchMock.mockImplementation((_input, init) => {
+        const method = init?.method ?? 'GET'
+        if (method === 'GET') {
+          return Promise.resolve(
+            jsonResponse({ username: 'alice', preferences: { diet: ['vegan', 'keto'] } }),
+          )
+        }
+        return new Promise<Response>((resolve) => {
+          pending.push(() => resolve(jsonResponse({})))
+        })
+      })
+      const user = userEvent.setup()
+      await renderSettled()
+
+      const vegan = screen.getByDisplayValue('vegan')
+      await user.click(trashIn(vegan))
+
+      // the row stays on screen but disabled until the server answers
+      expect(vegan).toBeDisabled()
+      expect(trashIn(vegan)).toBeDisabled()
+      // the PUT persists the list without the deleted row
+      await waitFor(() => expect(pending).toHaveLength(1), { timeout: 2000 })
+      expect(lastPutBody().preferences.diet).toEqual(['keto'])
+
+      // only once it succeeds does the row leave the list
+      await resolveAndFlush(pending[0])
+      expect(screen.queryByDisplayValue('vegan')).toBeNull()
+      expect(screen.getByDisplayValue('keto')).toBeInTheDocument()
+    })
+
+    it('brings a row back and shows the error when its deletion fails', async () => {
+      fetchMock.mockImplementation((_input, init) => {
+        const method = init?.method ?? 'GET'
+        if (method === 'GET') {
+          return Promise.resolve(
+            jsonResponse({ username: 'alice', preferences: { diet: ['vegan', 'keto'] } }),
+          )
+        }
+        return Promise.resolve(jsonResponse({ message: 'Nope' }, { status: 500 }))
+      })
+      const user = userEvent.setup()
+      await renderSettled()
+
+      const vegan = screen.getByDisplayValue('vegan')
+      await user.click(trashIn(vegan))
+
+      await waitFor(() => expect(screen.getByText('Nope')).toBeInTheDocument(), { timeout: 2000 })
+      // the row is still there and interactive again
+      expect(vegan).toBeInTheDocument()
+      expect(vegan).not.toBeDisabled()
+      expect(trashIn(vegan)).not.toBeDisabled()
     })
   })
 })

--- a/web-client/tests/pages/ProfilePage.test.tsx
+++ b/web-client/tests/pages/ProfilePage.test.tsx
@@ -110,25 +110,68 @@ describe('ProfilePage', () => {
       ).toBeNull()
     })
 
-    it('shows a spinner while typing, then saves the trimmed value after a pause and flashes a check that fades out', async () => {
-      defaultProfileFetch({ username: 'alice' })
+    it('shows no spinner while typing, spins only once the request is sent, then flashes a check that fades out', async () => {
+      // PUTs resolve only when we say so, so we can observe the spinner appear
+      // exactly when the request goes out (not while typing)
+      const pending: Array<() => void> = []
+      fetchMock.mockImplementation((_input, init) => {
+        const method = init?.method ?? 'GET'
+        if (method === 'GET') {
+          return Promise.resolve(jsonResponse({ username: 'alice', preferences: {} }))
+        }
+        return new Promise<Response>((resolve) => {
+          pending.push(() => resolve(jsonResponse({})))
+        })
+      })
       const user = userEvent.setup()
       await renderSettled()
 
       await user.type(screen.getByLabelText('About me'), '  spicy food  ')
 
-      // spinner is showing immediately and nothing has been sent yet
-      expect(status()).toBe('saving')
+      // while typing: no spinner yet and nothing has been sent
+      expect(status()).toBe('idle')
       expect(putCalls()).toHaveLength(0)
 
       // once the user pauses, the request goes out with the trimmed value
-      await waitFor(() => expect(putCalls()).toHaveLength(1), { timeout: 2000 })
+      await waitFor(() => expect(pending).toHaveLength(1), { timeout: 2000 })
       expect(lastPutBody().preferences.aboutMe).toEqual(['spicy food'])
+      // the spinner only appears once the request outlasts its grace period
+      await waitFor(() => expect(status()).toBe('saving'), { timeout: 2000 })
 
       // the green check appears...
+      await resolveAndFlush(pending[0])
       await waitFor(() => expect(status()).toBe('saved'))
-      // ...and clears itself shortly after
-      await waitFor(() => expect(activeIndicator()).toBeNull(), { timeout: 2000 })
+      // ...lingers, then clears itself
+      await waitFor(() => expect(activeIndicator()).toBeNull(), { timeout: 3000 })
+    })
+
+    it('never flashes the spinner for a save that finishes within the grace period', async () => {
+      // the PUT resolves immediately — well inside the spinner grace period
+      defaultProfileFetch({ username: 'alice' })
+      const user = userEvent.setup()
+      await renderSettled()
+
+      // record every status the indicator passes through
+      const seen = new Set<string>()
+      const observer = new MutationObserver((mutations) => {
+        for (const m of mutations) {
+          const value = (m.target as Element).getAttribute?.('data-status')
+          if (value) seen.add(value)
+        }
+      })
+      observer.observe(document.body, {
+        subtree: true,
+        attributes: true,
+        attributeFilter: ['data-status'],
+      })
+
+      await user.type(screen.getByLabelText('About me'), 'fast')
+      await waitFor(() => expect(putCalls()).toHaveLength(1), { timeout: 2000 })
+      await waitFor(() => expect(seen.has('saved')).toBe(true), { timeout: 2000 })
+      observer.disconnect()
+
+      // it went straight from idle to the check — no spinner in between
+      expect(seen.has('saving')).toBe(false)
     })
 
     it('debounces a burst of keystrokes into a single request', async () => {
@@ -179,7 +222,7 @@ describe('ProfilePage', () => {
       await user.type(aboutMe, 'a')
       // first request fires after the debounce and is now in flight
       await waitFor(() => expect(pending).toHaveLength(1), { timeout: 2000 })
-      expect(status()).toBe('saving')
+      await waitFor(() => expect(status()).toBe('saving'), { timeout: 2000 })
 
       // user keeps typing before the server answers
       await user.type(aboutMe, 'b')
@@ -195,7 +238,7 @@ describe('ProfilePage', () => {
       await waitFor(() => expect(status()).toBe('saved'))
     })
 
-    it('surfaces a server error when the save fails', async () => {
+    it('shows a warning sign and message when the save fails, and clears it on the next edit', async () => {
       fetchMock.mockImplementation((_input, init) => {
         const method = init?.method ?? 'GET'
         if (method === 'GET') {
@@ -206,13 +249,40 @@ describe('ProfilePage', () => {
       const user = userEvent.setup()
       await renderSettled()
 
-      await user.type(screen.getByLabelText('About me'), 'spicy')
+      const aboutMe = screen.getByLabelText('About me')
+      await user.type(aboutMe, 'spicy')
 
-      // the error is surfaced and the spinner is gone
+      // the message is surfaced and a warning sign sits beside the field
       await waitFor(() => expect(screen.getByText('Server on fire')).toBeInTheDocument(), {
         timeout: 2000,
       })
-      expect(activeIndicator()).toBeNull()
+      expect(status()).toBe('error')
+      expect(screen.getByTestId('save-error')).toBeInTheDocument()
+
+      // resuming typing clears the warning (no spinner until the next send)
+      await user.type(aboutMe, '!')
+      expect(status()).toBe('idle')
+    })
+
+    it('reports an unreachable server in plain language', async () => {
+      fetchMock.mockImplementation((_input, init) => {
+        const method = init?.method ?? 'GET'
+        if (method === 'GET') {
+          return Promise.resolve(jsonResponse({ username: 'alice', preferences: {} }))
+        }
+        // what fetch throws when the server is down / connection refused
+        return Promise.reject(new TypeError('Failed to fetch'))
+      })
+      const user = userEvent.setup()
+      await renderSettled()
+
+      await user.type(screen.getByLabelText('About me'), 'spicy')
+
+      await waitFor(
+        () => expect(screen.getByText("Couldn't reach the server")).toBeInTheDocument(),
+        { timeout: 2000 },
+      )
+      expect(screen.getByTestId('save-error')).toBeInTheDocument()
     })
   })
 })


### PR DESCRIPTION
## What

Taste preferences on the profile page now save automatically as you type — the **Update taste preferences** button is gone. Each field shows its own inline status indicator.

## Behaviour

- **Debounced autosave**: a save fires ~400ms after you stop typing; one `PUT /api/v1/users/profile` persists all preferences (about-me, diet, allergies), with empty entries stripped.
- **Spinner**: shown only once a request is actually in flight *and* it outlasts a 300ms grace period — no spinner while typing, and no flicker for fast saves.
- **Saved check**: a green check appears on success, holds, then fades out (~1.5s).
- **Type-during-save**: if you keep typing while a save is in flight, the check flashes in the middle of the spinner and the latest value is saved again once you stop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## To Do
- review tests