### PR TITLE
Recipe tag search and two-page generation flow

### DIFF
--- a/web-client/src/App.tsx
+++ b/web-client/src/App.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from 'react'
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
 import { AuthProvider, useAuth } from './auth'
 import { AppLayout } from './components/AppLayout'
-import { GeneratePage } from './pages/GeneratePage'
+import { GenerateFlow, GeneratePage, GenerateResultsPage } from './pages/GeneratePage'
 import { LibraryPage } from './pages/LibraryPage'
 import { LoginPage } from './pages/LoginPage'
 import { NotFoundPage } from './pages/NotFoundPage'
@@ -28,8 +28,11 @@ export default function App() {
               </RequireAuth>
             }
           >
-            <Route path="/generate" element={<GeneratePage />} />
-            <Route path="/generate/recipe" element={<RecipePage />} />
+            <Route path="/generate" element={<GenerateFlow />}>
+              <Route index element={<GeneratePage />} />
+              <Route path="results" element={<GenerateResultsPage />} />
+              <Route path="recipe" element={<RecipePage />} />
+            </Route>
             <Route path="/library" element={<LibraryPage />} />
             <Route path="/library/recipe/:recipeId" element={<RecipePage />} />
             <Route path="/profile" element={<ProfilePage />} />

--- a/web-client/src/components/TagSelector.tsx
+++ b/web-client/src/components/TagSelector.tsx
@@ -59,6 +59,7 @@ export function TagSelector({selectedTags, onChange}: TagSelectorProps) {
                   <button
                     key={tag.id}
                     type="button"
+                    aria-pressed={active}
                     onClick={() => toggle(tag.id)}
                     className={`px-3 py-1 rounded-full border text-sm cursor-pointer transition-colors ${
                       active ? 'bg-orange-500 text-white border-orange-500' : tint

--- a/web-client/src/components/TagSelector.tsx
+++ b/web-client/src/components/TagSelector.tsx
@@ -1,0 +1,77 @@
+import {facets, tags, tagsById} from '../recipeFormat'
+
+// background by reveal order: defaults (0) are neutral, each further hop is a touch more orange.
+const TINT_BY_ORDER = [
+  'bg-white text-gray-700 border-gray-300 hover:border-orange-400',
+  'bg-orange-50 text-gray-800 border-orange-200 hover:border-orange-400',
+  'bg-orange-100 text-gray-800 border-orange-300 hover:border-orange-400',
+  'bg-orange-200 text-gray-900 border-orange-300 hover:border-orange-500',
+  'bg-orange-300 text-gray-900 border-orange-400 hover:border-orange-500',
+]
+
+interface TagSelectorProps {
+  selectedTags: string[]
+  onChange: (selected: string[]) => void
+}
+
+export function TagSelector({selectedTags, onChange}: TagSelectorProps) {
+  const selectedTagsSet = new Set(selectedTags)
+
+  // order = number of "reveal-hops" from a default tag, walking only through selected tags.
+  const order = new Map<string, number>()
+  for (const facet of facets) for (const id of facet.defaultTags) order.set(id, 0)
+  let changed = true
+  while (changed) {
+    changed = false
+    for (const id of selectedTags) {
+      const depth = order.get(id)
+      if (depth === undefined) continue
+      for (const revealed of tagsById.get(id)?.reveals ?? []) {
+        if ((order.get(revealed) ?? Infinity) > depth + 1) {
+          order.set(revealed, depth + 1)
+          changed = true
+        }
+      }
+    }
+  }
+  // keep a selected tag visible even if the parent that revealed it was since deselected
+  for (const id of selectedTags) if (!order.has(id)) order.set(id, 0)
+
+  function toggle(id: string) {
+    onChange(selectedTagsSet.has(id) ? selectedTags.filter((s) => s !== id) : [...selectedTags, id])
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      {facets.map((facet) => {
+        const facetTags = tags
+          .filter((tag) => tag.categoryId === facet.id && order.has(tag.id))
+          .sort((a, b) => order.get(a.id)! - order.get(b.id)!)
+        if (facetTags.length === 0) return null
+        return (
+          <div key={facet.id}>
+            <h3 className="text-sm font-semibold text-gray-700 mb-1">{facet.label}</h3>
+            <div className="flex flex-wrap gap-2">
+              {facetTags.map((tag) => {
+                const active = selectedTagsSet.has(tag.id)
+                const tint = TINT_BY_ORDER[Math.min(order.get(tag.id)!, TINT_BY_ORDER.length - 1)]
+                return (
+                  <button
+                    key={tag.id}
+                    type="button"
+                    onClick={() => toggle(tag.id)}
+                    className={`px-3 py-1 rounded-full border text-sm cursor-pointer transition-colors ${
+                      active ? 'bg-orange-500 text-white border-orange-500' : tint
+                    }`}
+                  >
+                    {tag.label}
+                  </button>
+                )
+              })}
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/web-client/src/index.css
+++ b/web-client/src/index.css
@@ -35,4 +35,21 @@
       transform: scale(0.92);
     }
   }
+
+  /* translate stays within the layout's 1.5rem padding so the slide never adds a scrollbar */
+  --animate-slide-from-right: slide-from-right 220ms ease-out;
+  @keyframes slide-from-right {
+    from {
+      opacity: 0;
+      transform: translateX(1.5rem);
+    }
+  }
+
+  --animate-slide-from-left: slide-from-left 220ms ease-out;
+  @keyframes slide-from-left {
+    from {
+      opacity: 0;
+      transform: translateX(-1.5rem);
+    }
+  }
 }

--- a/web-client/src/index.css
+++ b/web-client/src/index.css
@@ -1,67 +1,70 @@
 @import "tailwindcss";
+
 @plugin "@tailwindcss/typography";
 
 @font-face {
-  font-family: 'Outfit';
-  font-style: normal;
-  font-weight: 100 900;
-  font-display: swap;
-  src: url('/fonts/outfit-latin.woff2') format('woff2');
-  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+	font-family: 'Outfit';
+	font-style: normal;
+	font-weight: 100 900;
+	font-display: swap;
+	src: url('/fonts/outfit-latin.woff2') format('woff2');
+	unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
 @font-face {
-  font-family: 'Outfit';
-  font-style: normal;
-  font-weight: 100 900;
-  font-display: swap;
-  src: url('/fonts/outfit-latin-ext.woff2') format('woff2');
-  unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+	font-family: 'Outfit';
+	font-style: normal;
+	font-weight: 100 900;
+	font-display: swap;
+	src: url('/fonts/outfit-latin-ext.woff2') format('woff2');
+	unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
 @theme {
-  --font-sans: 'Outfit', ui-sans-serif, system-ui, -apple-system, sans-serif;
+	--font-sans: 'Outfit', ui-sans-serif, system-ui, -apple-system, sans-serif;
 
-  --animate-fade-in: fade-in 150ms ease-out;
-  @keyframes fade-in {
-    from {
-      opacity: 0;
-    }
-  }
+	--animate-fade-in: fade-in 150ms ease-out;
+	@keyframes fade-in {
+		from {
+			opacity: 0;
+		}
+	}
 
-  --animate-press: press 150ms ease-out;
-  @keyframes press {
-    50% {
-      transform: scale(0.92);
-    }
-  }
+	--animate-press: press 150ms ease-out;
+	@keyframes press {
+		50% {
+			transform: scale(0.92);
+		}
+	}
 
-  /* translate stays within the layout's 1.5rem padding so the slide never adds a scrollbar */
-  --animate-slide-from-right: slide-from-right 220ms ease-out;
-  @keyframes slide-from-right {
-    from {
-      opacity: 0;
-      transform: translateX(1.5rem);
-    }
-  }
+	/* translate stays within the layout's 1.5rem padding so the slide never adds a scrollbar */
+	--animate-slide-from-right: slide-from-right 220ms ease-out;
+	@keyframes slide-from-right {
+		from {
+			opacity: 0;
+			transform: translateX(1.5rem);
+		}
+	}
 
-  --animate-slide-from-left: slide-from-left 220ms ease-out;
-  @keyframes slide-from-left {
-    from {
-      opacity: 0;
-      transform: translateX(-1.5rem);
-      
-  /* checkmark holds for a moment once a field is saved, then fades away */
-  --animate-fade-out: fade-out 1500ms ease-in forwards;
-  @keyframes fade-out {
-    0%,
-    66% {
-      opacity: 1;
-      transform: scale(1);
-    }
-    100% {
-      opacity: 0;
-      transform: scale(0.6);
-    }
-  }
+	--animate-slide-from-left: slide-from-left 220ms ease-out;
+	@keyframes slide-from-left {
+		from {
+			opacity: 0;
+			transform: translateX(-1.5rem);
+		}
+	}
+
+	/* checkmark holds for a moment once a field is saved, then fades away */
+	--animate-fade-out: fade-out 1500ms ease-in forwards;
+	@keyframes fade-out {
+		0%,
+		66% {
+			opacity: 1;
+			transform: scale(1);
+		}
+		100% {
+			opacity: 0;
+			transform: scale(0.6);
+		}
+	}
 }

--- a/web-client/src/pages/GeneratePage.tsx
+++ b/web-client/src/pages/GeneratePage.tsx
@@ -1,8 +1,12 @@
 import {useEffect, useState} from 'react'
-import {useNavigate} from 'react-router-dom'
+import type {Dispatch, SetStateAction} from 'react'
+import {Outlet, useLocation, useNavigate, useOutletContext} from 'react-router-dom'
+import {ChevronRightIcon, PencilSquareIcon} from '@heroicons/react/24/outline'
 import type {components} from '../api'
 import {Button} from '../components/Button'
 import {RecipeCard} from '../components/RecipeCard'
+import {TagSelector} from '../components/TagSelector'
+import {tagsById} from '../recipeFormat'
 import {usePressPulse} from '../usePressPulse'
 import {errorMessage} from '../apiError'
 import {SessionExpiredError, useApi} from '../useApi'
@@ -11,18 +15,43 @@ import {SessionExpiredError, useApi} from '../useApi'
 type Recipe = components['schemas']['RecipeInput'] & { id?: number }
 type RecipeRequest = components['schemas']['RecipeRequest']
 
-export function GeneratePage() {
-  const apiFetch = useApi()
-  const navigate = useNavigate()
-  const [generateBtnRef, pulseGenerate] = usePressPulse<HTMLButtonElement>()
-  const [prompt, setPrompt] = useState(() => sessionStorage.getItem('recipe_prompt') ?? '')
-  // keep the last results so the list is restored when returning from a recipe page
-  const [recipes, setRecipes] = useState<Recipe[]>(() => {
-    const stored = sessionStorage.getItem('generated_recipes')
-    return stored ? (JSON.parse(stored) as Recipe[]) : []
-  })
-  const [status, setStatus] = useState<string | null>(null)
-  const [loading, setLoading] = useState(false)
+interface RecipeGenerationContext {
+	prompt: string
+	setPrompt: Dispatch<SetStateAction<string>>
+	selectedTags: string[]
+	setSelectedTags: Dispatch<SetStateAction<string[]>>
+	recipes: Recipe[]
+	setRecipes: Dispatch<SetStateAction<Recipe[]>>
+	status: string | null
+	loading: boolean
+	generate: () => void
+}
+
+const VIEW_ORDER = {options: 0, results: 1, recipe: 2} as const
+
+function viewName(pathname: string): keyof typeof VIEW_ORDER {
+	if (pathname.startsWith('/generate/results')) return 'results'
+	if (pathname.startsWith('/generate/recipe')) return 'recipe'
+	return 'options'
+}
+
+export function GenerateFlow() {
+	const apiFetch = useApi()
+	const navigate = useNavigate()
+	const {pathname} = useLocation()
+
+	const [prompt, setPrompt] = useState(() => sessionStorage.getItem('recipe_prompt') ?? '')
+	const [selectedTags, setSelectedTags] = useState<string[]>(() => {
+		const stored = sessionStorage.getItem('recipe_tags')
+		return stored ? (JSON.parse(stored) as string[]) : []
+	})
+	// keep the last results so the list is restored when returning from a recipe page
+	const [recipes, setRecipes] = useState<Recipe[]>(() => {
+		const stored = sessionStorage.getItem('generated_recipes')
+		return stored ? (JSON.parse(stored) as Recipe[]) : []
+	})
+	const [status, setStatus] = useState<string | null>(null)
+	const [loading, setLoading] = useState(false)
 
 	// Confirm the session is still valid
 	useEffect(() => {
@@ -30,79 +59,172 @@ export function GeneratePage() {
 		apiFetch('/users/profile')
 	}, [apiFetch])
 
-  useEffect(() => {
-    sessionStorage.setItem('generated_recipes', JSON.stringify(recipes))
-  }, [recipes])
+	useEffect(() => {
+		sessionStorage.setItem('generated_recipes', JSON.stringify(recipes))
+	}, [recipes])
 
-  async function handleGenerate() {
-    setLoading(true)
-    setStatus('Generating recipes… (this might take a while)')
-    setRecipes([])
-    sessionStorage.setItem('recipe_prompt', prompt)
-    try {
-      const body: RecipeRequest = { prompt }
-		const response = await apiFetch('/ai/recipes', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify(body),
-      })
-      if (!response.ok) throw new Error(await errorMessage(response))
-      const data = (await response.json()) as Recipe[]
-      setRecipes(data)
-      setStatus(data.length === 0 ? 'No recipes returned.' : null)
-    } catch (e) {
-      if (e instanceof SessionExpiredError) return
-      setStatus(`Error: ${e instanceof Error ? e.message : String(e)}`)
-    } finally {
-      setLoading(false)
-    }
-  }
+	async function generate() {
+		setLoading(true)
+		setStatus('Generating recipes… (this might take a while)')
+		setRecipes([])
+		sessionStorage.setItem('recipe_prompt', prompt)
+		sessionStorage.setItem('recipe_tags', JSON.stringify(selectedTags))
+		navigate('/generate/results')
+		try {
+			const tagLabels = selectedTags.map((id) => tagsById.get(id)?.label).filter(Boolean)
+			const fullPrompt = tagLabels.length > 0 ? `${prompt}\n\nPreferences: ${tagLabels.join(', ')}` : prompt
+			const body: RecipeRequest = {prompt: fullPrompt}
+			const response = await apiFetch('/ai/recipes', {
+				method: 'POST',
+				headers: {'content-type': 'application/json'},
+				body: JSON.stringify(body),
+			})
+			if (!response.ok) throw new Error(await errorMessage(response))
+			const data = (await response.json()) as Recipe[]
+			setRecipes(data)
+			setStatus(data.length === 0 ? 'No recipes returned.' : null)
+		} catch (e) {
+			if (e instanceof SessionExpiredError) return
+			setStatus(`Error: ${e instanceof Error ? e.message : String(e)}`)
+		} finally {
+			setLoading(false)
+		}
+	}
 
-  function handleSavedIdChange(index: number, newId: number | undefined) {
-    setRecipes((prev) => prev.map((prevRecipe, prevIndex) => (prevIndex === index ? { ...prevRecipe, id: newId } : prevRecipe)))
-  }
+	const view = viewName(pathname)
+	const [prevView, setPrevView] = useState(view)
+	const [slideDirectionBack, setSlideDirectionBack] = useState(false)
+	if (view !== prevView) {
+		setSlideDirectionBack(VIEW_ORDER[view] < VIEW_ORDER[prevView])
+		setPrevView(view)
+	}
 
-  return (
-    <>
-      <h2 className="text-lg font-bold">What do you want to cook today?</h2>
-      <textarea
-        className="w-full min-h-32 border border-gray-300 rounded p-3"
-        placeholder="What do you want to cook? (e.g. ingredients, cuisine, constraints)"
-        value={prompt}
-        onChange={(e) => setPrompt(e.target.value)}
-        onFocus={(e) => e.target.select()}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter' && !e.shiftKey) {
-            // on Enter: directly submit instead of adding a new line
-            e.preventDefault()
-            if (!loading && prompt.trim() !== '') {
-              pulseGenerate()
-              handleGenerate()
-            }
-          }
-        }}
-      />
-      <Button
-        ref={generateBtnRef}
-        type="button"
-        className="self-start"
-        onClick={handleGenerate}
-        disabled={loading || prompt.trim() === ''}
-      >
-        {loading ? 'Generating…' : 'Generate'}
-      </Button>
+	const context: RecipeGenerationContext = {
+		prompt, setPrompt, selectedTags, setSelectedTags, recipes, setRecipes, status, loading, generate,
+	}
 
-      {status && <p className="text-gray-600">{status}</p>}
+	return (
+		<div
+			key={view}
+			className={`flex flex-col gap-4 ${slideDirectionBack ? 'animate-slide-from-left' : 'animate-slide-from-right'}`}
+		>
+			<Outlet context={context}/>
+		</div>
+	)
+}
 
-      {recipes.map((recipe, index) => (
-        <RecipeCard
-          key={index}
-          recipe={recipe}
-          recipeId={recipe.id}
-          onSavedIdChange={(newId) => handleSavedIdChange(index, newId)}
-          onOpen={() => navigate('/generate/recipe', {state: {index}})}
-        />
-      ))}
-    </>
-  )
+export function GeneratePage() {
+	const navigate = useNavigate()
+	const {
+		prompt,
+		setPrompt,
+		selectedTags,
+		setSelectedTags,
+		recipes,
+		loading,
+		generate
+	} = useOutletContext<RecipeGenerationContext>()
+	const [generateBtnRef, pulseGenerate] = usePressPulse<HTMLButtonElement>()
+
+	return (
+		<>
+			<div className="flex items-center justify-between gap-3">
+				<h2 className="text-lg font-bold">What do you want to cook today?</h2>
+				{recipes.length > 0 && (
+					<button
+						type="button"
+						className="flex shrink-0 items-center gap-1 text-sm text-gray-500 cursor-pointer transition-transform duration-100 hover:scale-98"
+						onClick={() => navigate('/generate/results')}
+					>
+						View recipes
+						<ChevronRightIcon className="h-4 w-4"/>
+					</button>
+				)}
+			</div>
+			<textarea
+				className="w-full min-h-32 border border-gray-300 rounded p-3"
+				placeholder="Type what you think (optional)"
+				value={prompt}
+				onChange={(e) => setPrompt(e.target.value)}
+				onFocus={(e) => e.target.select()}
+				onKeyDown={(e) => {
+					if (e.key === 'Enter' && !e.shiftKey) {
+						// on Enter: directly submit instead of adding a new line
+						e.preventDefault()
+						if (!loading && (prompt.trim() !== '' || selectedTags.length > 0)) {
+							pulseGenerate()
+							generate()
+						}
+					}
+				}}
+			/>
+
+			<TagSelector selectedTags={selectedTags} onChange={setSelectedTags}/>
+
+			<Button
+				ref={generateBtnRef}
+				type="button"
+				className="self-center"
+				onClick={generate}
+				disabled={loading || (prompt.trim() === '' && selectedTags.length === 0)}
+			>
+				{loading ? 'Generating…' : 'Generate'}
+			</Button>
+		</>
+	)
+}
+
+export function GenerateResultsPage() {
+	const navigate = useNavigate()
+	const {prompt, selectedTags, recipes, status, setRecipes} = useOutletContext<RecipeGenerationContext>()
+
+	function handleSavedIdChange(index: number, newId: number | undefined) {
+		setRecipes((prev) => prev.map((prevRecipe, prevIndex) => (prevIndex === index ? {
+			...prevRecipe,
+			id: newId
+		} : prevRecipe)))
+	}
+
+	return (
+		<>
+			<div className="flex items-start justify-between gap-3 rounded-lg border border-gray-200 bg-gray-50 p-3">
+				<div className="flex min-w-0 flex-col gap-2">
+					{prompt.trim() !== '' && <p className="text-sm text-gray-700 line-clamp-2">{prompt}</p>}
+					{selectedTags.length > 0 && (
+						<div className="flex flex-wrap gap-1.5">
+							{selectedTags.map((id) => (
+								<span key={id}
+								      className="rounded-full border border-gray-200 bg-white px-2 py-0.5 text-xs text-gray-600">
+                  {tagsById.get(id)?.label ?? id}
+                </span>
+							))}
+						</div>
+					)}
+					{prompt.trim() === '' && selectedTags.length === 0 && (
+						<p className="text-sm text-gray-400">No options selected</p>
+					)}
+				</div>
+				<button
+					type="button"
+					className="flex shrink-0 items-center gap-1 self-start text-sm text-gray-500 cursor-pointer transition-transform duration-100 hover:scale-98"
+					onClick={() => navigate('/generate')}
+				>
+					<PencilSquareIcon className="h-4 w-4"/>
+					Edit
+				</button>
+			</div>
+
+			{status && <p className="text-gray-600">{status}</p>}
+
+			{recipes.map((recipe, index) => (
+				<RecipeCard
+					key={index}
+					recipe={recipe}
+					recipeId={recipe.id}
+					onSavedIdChange={(newId) => handleSavedIdChange(index, newId)}
+					onOpen={() => navigate('/generate/recipe', {state: {index}})}
+				/>
+			))}
+		</>
+	)
 }

--- a/web-client/src/pages/GeneratePage.tsx
+++ b/web-client/src/pages/GeneratePage.tsx
@@ -15,7 +15,7 @@ import {SessionExpiredError, useApi} from '../useApi'
 type Recipe = components['schemas']['RecipeInput'] & { id?: number }
 type RecipeRequest = components['schemas']['RecipeRequest']
 
-interface RecipeGenerationContext {
+export interface RecipeGenerationContext {
 	prompt: string
 	setPrompt: Dispatch<SetStateAction<string>>
 	selectedTags: string[]

--- a/web-client/src/pages/RecipePage.tsx
+++ b/web-client/src/pages/RecipePage.tsx
@@ -65,7 +65,7 @@ function GeneratedRecipePage() {
     <RecipeView
       key={index}
       recipe={recipe}
-      parentPath="/generate"
+      parentPath="/generate/results"
       onSavedIdChange={handleSavedIdChange}
       answers={helpAnswers[index] ?? []}
       onAnswer={(entry) => setHelpAnswers((m) => ({ ...m, [index]: [entry, ...(m[index] ?? [])] }))}

--- a/web-client/src/pages/RecipePage.tsx
+++ b/web-client/src/pages/RecipePage.tsx
@@ -8,8 +8,9 @@ import {
   PlusIcon,
 } from '@heroicons/react/24/outline'
 import Markdown from 'react-markdown'
-import { Link, Navigate, useLocation, useNavigate, useParams } from 'react-router-dom'
+import { Link, Navigate, useLocation, useNavigate, useOutletContext, useParams } from 'react-router-dom'
 import type { components } from '../api'
+import type { RecipeGenerationContext } from './GeneratePage'
 import { RecipeSaveButton } from '../components/RecipeSaveButton.tsx'
 import { formatQuantity } from '../recipeFormat'
 import { usePressPulse } from '../usePressPulse'
@@ -23,13 +24,6 @@ type HelpEntry = { question: string; answer: string }
 
 type Pagination = { index: number; count: number; onNavigate: (index: number) => void }
 
-const GENERATED_STORAGE_KEY = 'generated_recipes'
-
-function readGenerated(): Recipe[] {
-  const stored = sessionStorage.getItem(GENERATED_STORAGE_KEY)
-  return stored ? (JSON.parse(stored) as Recipe[]) : []
-}
-
 function toggleSetItem(set: Set<number>, item: number): Set<number> {
   const next = new Set(set)
   if (next.has(item)) next.delete(item)
@@ -42,21 +36,20 @@ export function RecipePage() {
   return pathname.startsWith('/library/') ? <LibraryRecipePage key={pathname} /> : <GeneratedRecipePage />
 }
 
-// Generated recipes live in sessionStorage and are paged through by list index in router state.
+// Generated recipes are shared with the GenerateFlow layout (which persists them to sessionStorage)
+// and are paged through by list index in router state.
 function GeneratedRecipePage() {
   const location = useLocation()
   const navigate = useNavigate()
   const index = (location.state as { index?: number } | null)?.index ?? 0
-  const [recipes, setRecipes] = useState<Recipe[]>(() => readGenerated())
+  const { recipes, setRecipes } = useOutletContext<RecipeGenerationContext>()
   const [helpAnswers, setHelpAnswers] = useState<Record<number, HelpEntry[]>>({})
   const recipe = recipes[index]
 
   function handleSavedIdChange(newId: number | undefined) {
-    setRecipes((prev) => {
-      const next = prev.map((prevRecipe, prevIndex) => (prevIndex === index ? { ...prevRecipe, id: newId } : prevRecipe))
-      sessionStorage.setItem(GENERATED_STORAGE_KEY, JSON.stringify(next))
-      return next
-    })
+    setRecipes((prev) =>
+      prev.map((prevRecipe, prevIndex) => (prevIndex === index ? { ...prevRecipe, id: newId } : prevRecipe)),
+    )
   }
 
   if (!recipe) return <Navigate to="/generate" replace />

--- a/web-client/src/recipeFormat.ts
+++ b/web-client/src/recipeFormat.ts
@@ -1,31 +1,51 @@
+import recipeTags from './recipeTags.json'
+
 const FRACTIONS: [number, string][] = [
-  [1 / 8, '⅛'],
-  [1 / 6, '⅙'],
-  [1 / 5, '⅕'],
-  [1 / 4, '¼'],
-  [1 / 3, '⅓'],
-  [3 / 8, '⅜'],
-  [2 / 5, '⅖'],
-  [1 / 2, '½'],
-  [3 / 5, '⅗'],
-  [5 / 8, '⅝'],
-  [2 / 3, '⅔'],
-  [3 / 4, '¾'],
-  [4 / 5, '⅘'],
-  [5 / 6, '⅚'],
-  [7 / 8, '⅞'],
+	[1 / 8, '⅛'],
+	[1 / 6, '⅙'],
+	[1 / 5, '⅕'],
+	[1 / 4, '¼'],
+	[1 / 3, '⅓'],
+	[3 / 8, '⅜'],
+	[2 / 5, '⅖'],
+	[1 / 2, '½'],
+	[3 / 5, '⅗'],
+	[5 / 8, '⅝'],
+	[2 / 3, '⅔'],
+	[3 / 4, '¾'],
+	[4 / 5, '⅘'],
+	[5 / 6, '⅚'],
+	[7 / 8, '⅞'],
 ]
 
 // scale a quantity to the chosen portions, rendering fractional parts as glyphs (e.g. 1.5 → "1 ½")
 export function formatQuantity(quantity: number, scale = 1): string {
-  const value = quantity * scale
-  // for larger amounts, plain digits read better than mixed-fraction glyphs
-  if (value <= 5) {
-    const whole = Math.floor(value)
-    const frac = value - whole
-    const glyph = FRACTIONS.find(([f]) => Math.abs(frac - f) < 0.02)?.[1]
-    if (glyph) return whole > 0 ? `${whole} ${glyph}` : glyph
-  }
-  // round to 2 decimals and drop trailing zeros
-  return String(Math.round(value * 100) / 100)
+	const value = quantity * scale
+	// for larger amounts, plain digits read better than mixed-fraction glyphs
+	if (value <= 5) {
+		const whole = Math.floor(value)
+		const frac = value - whole
+		const glyph = FRACTIONS.find(([f]) => Math.abs(frac - f) < 0.02)?.[1]
+		if (glyph) return whole > 0 ? `${whole} ${glyph}` : glyph
+	}
+	// round to 2 decimals and drop trailing zeros
+	return String(Math.round(value * 100) / 100)
 }
+
+export interface RecipeCategory {
+	id: string
+	label: string
+	defaultTags: string[]
+}
+
+export interface RecipeTag {
+	id: string
+	label: string
+	categoryId: string
+	/** Tag ids that are shown once this tag is selected */
+	reveals: string[]
+}
+
+export const facets: RecipeCategory[] = recipeTags.facets
+export const tags: RecipeTag[] = recipeTags.tags
+export const tagsById: Map<string, RecipeTag> = new Map(tags.map((tag) => [tag.id, tag]))

--- a/web-client/src/recipeTags.json
+++ b/web-client/src/recipeTags.json
@@ -1,0 +1,2480 @@
+{
+  "facets": [
+    {
+      "id": "meal-type",
+      "label": "Type of Meal",
+      "defaultTags": [
+        "dinner",
+        "lunch",
+        "breakfast",
+        "dessert",
+        "snack",
+        "appetizer"
+      ]
+    },
+    {
+      "id": "cuisine",
+      "label": "Cuisine",
+      "defaultTags": [
+        "italian",
+        "chinese",
+        "mexican",
+        "indian",
+        "american",
+        "japanese",
+        "thai",
+        "mediterranean",
+        "french",
+        "korean",
+        "vietnamese",
+        "latin-american",
+        "british",
+        "german"
+      ]
+    },
+    {
+      "id": "ingredient",
+      "label": "Main Ingredient",
+      "defaultTags": [
+        "chicken",
+        "beef",
+        "pork",
+        "eggs",
+        "cheese",
+        "pasta",
+        "vegetables",
+        "fish"
+      ]
+    },
+    {
+      "id": "occasion",
+      "label": "Occasion & Season",
+      "defaultTags": [
+        "weeknight",
+        "party",
+        "bbq",
+        "festival",
+        "summer",
+        "winter",
+        "spring",
+        "autumn"
+      ]
+    },
+    {
+      "id": "method",
+      "label": "Cooking Method",
+      "defaultTags": [
+        "baking",
+        "grilling",
+        "frying",
+        "air-fryer",
+        "slow-cooker",
+        "one-pot",
+        "steaming",
+        "no-cook"
+      ]
+    }
+  ],
+  "tags": [
+    {
+      "id": "dinner",
+      "label": "Dinner",
+      "categoryId": "meal-type",
+      "reveals": [
+        "burger",
+        "casserole",
+        "curry",
+        "main-course",
+        "pasta",
+        "pizza",
+        "roast",
+        "side-dish",
+        "stir-fry"
+      ]
+    },
+    {
+      "id": "lunch",
+      "label": "Lunch",
+      "categoryId": "meal-type",
+      "reveals": [
+        "bowls",
+        "burger",
+        "pizza",
+        "salad",
+        "sandwich",
+        "soup",
+        "wrap"
+      ]
+    },
+    {
+      "id": "breakfast",
+      "label": "Breakfast",
+      "categoryId": "meal-type",
+      "reveals": [
+        "breakfast-bowl",
+        "brunch",
+        "eggs",
+        "muffins",
+        "oatmeal",
+        "pancakes",
+        "smoothie"
+      ]
+    },
+    {
+      "id": "dessert",
+      "label": "Dessert",
+      "categoryId": "meal-type",
+      "reveals": [
+        "brownies",
+        "cake",
+        "cheesecake",
+        "chocolate",
+        "cookies",
+        "ice-cream",
+        "pie",
+        "pudding"
+      ]
+    },
+    {
+      "id": "snack",
+      "label": "Snack",
+      "categoryId": "meal-type",
+      "reveals": [
+        "chips-crisps",
+        "dip",
+        "drinks",
+        "energy-balls",
+        "finger-food",
+        "popcorn",
+        "smoothie"
+      ]
+    },
+    {
+      "id": "appetizer",
+      "label": "Appetizer",
+      "categoryId": "meal-type",
+      "reveals": [
+        "bruschetta",
+        "dip",
+        "finger-food",
+        "soup",
+        "spring-rolls"
+      ]
+    },
+    {
+      "id": "pizza",
+      "label": "Pizza",
+      "categoryId": "meal-type",
+      "reveals": [
+        "cheese"
+      ]
+    },
+    {
+      "id": "burger",
+      "label": "Burger",
+      "categoryId": "meal-type",
+      "reveals": [
+        "beef"
+      ]
+    },
+    {
+      "id": "sandwich",
+      "label": "Sandwich",
+      "categoryId": "meal-type",
+      "reveals": [
+        "wrap"
+      ]
+    },
+    {
+      "id": "salad",
+      "label": "Salad",
+      "categoryId": "meal-type",
+      "reveals": [
+        "leafy-greens",
+        "vegetables"
+      ]
+    },
+    {
+      "id": "soup",
+      "label": "Soup",
+      "categoryId": "meal-type",
+      "reveals": [
+        "stew",
+        "vegetables"
+      ]
+    },
+    {
+      "id": "stir-fry",
+      "label": "Stir Fry",
+      "categoryId": "meal-type",
+      "reveals": [
+        "noodles",
+        "rice",
+        "tofu"
+      ]
+    },
+    {
+      "id": "curry",
+      "label": "Curry",
+      "categoryId": "meal-type",
+      "reveals": [
+        "chickpeas",
+        "lentils",
+        "rice"
+      ]
+    },
+    {
+      "id": "cake",
+      "label": "Cake",
+      "categoryId": "meal-type",
+      "reveals": [
+        "chocolate"
+      ]
+    },
+    {
+      "id": "cookies",
+      "label": "Cookies & Biscuits",
+      "categoryId": "meal-type",
+      "reveals": [
+        "chocolate"
+      ]
+    },
+    {
+      "id": "pancakes",
+      "label": "Pancakes",
+      "categoryId": "meal-type",
+      "reveals": []
+    },
+    {
+      "id": "wrap",
+      "label": "Wraps & Rolls",
+      "categoryId": "meal-type",
+      "reveals": []
+    },
+    {
+      "id": "roast",
+      "label": "Roast",
+      "categoryId": "meal-type",
+      "reveals": [
+        "duck",
+        "turkey"
+      ]
+    },
+    {
+      "id": "stew",
+      "label": "Stew",
+      "categoryId": "meal-type",
+      "reveals": []
+    },
+    {
+      "id": "casserole",
+      "label": "Casserole & Bake",
+      "categoryId": "meal-type",
+      "reveals": []
+    },
+    {
+      "id": "pie",
+      "label": "Pie",
+      "categoryId": "meal-type",
+      "reveals": []
+    },
+    {
+      "id": "smoothie",
+      "label": "Smoothie & Shake",
+      "categoryId": "meal-type",
+      "reveals": []
+    },
+    {
+      "id": "ice-cream",
+      "label": "Ice Cream",
+      "categoryId": "meal-type",
+      "reveals": []
+    },
+    {
+      "id": "bread",
+      "label": "Bread",
+      "categoryId": "meal-type",
+      "reveals": []
+    },
+    {
+      "id": "brunch",
+      "label": "Brunch",
+      "categoryId": "meal-type",
+      "reveals": [
+        "eggs",
+        "french-toast",
+        "pancakes",
+        "quiche",
+        "waffles"
+      ]
+    },
+    {
+      "id": "main-course",
+      "label": "Main Course",
+      "categoryId": "meal-type",
+      "reveals": [
+        "casserole",
+        "curry",
+        "roast",
+        "stir-fry"
+      ]
+    },
+    {
+      "id": "side-dish",
+      "label": "Side Dish",
+      "categoryId": "meal-type",
+      "reveals": [
+        "bread",
+        "potatoes",
+        "rice",
+        "roasted-veg",
+        "salad",
+        "vegetables"
+      ]
+    },
+    {
+      "id": "dip",
+      "label": "Dips & Spreads",
+      "categoryId": "meal-type",
+      "reveals": []
+    },
+    {
+      "id": "finger-food",
+      "label": "Finger Food",
+      "categoryId": "meal-type",
+      "reveals": [
+        "dip"
+      ]
+    },
+    {
+      "id": "muffins",
+      "label": "Muffins & Scones",
+      "categoryId": "meal-type",
+      "reveals": []
+    },
+    {
+      "id": "oatmeal",
+      "label": "Oatmeal & Porridge",
+      "categoryId": "meal-type",
+      "reveals": []
+    },
+    {
+      "id": "cheesecake",
+      "label": "Cheesecake",
+      "categoryId": "meal-type",
+      "reveals": []
+    },
+    {
+      "id": "brownies",
+      "label": "Brownies & Slices",
+      "categoryId": "meal-type",
+      "reveals": []
+    },
+    {
+      "id": "waffles",
+      "label": "Waffles",
+      "categoryId": "meal-type",
+      "reveals": []
+    },
+    {
+      "id": "french-toast",
+      "label": "French Toast",
+      "categoryId": "meal-type",
+      "reveals": []
+    },
+    {
+      "id": "quiche",
+      "label": "Quiche & Savoury Tart",
+      "categoryId": "meal-type",
+      "reveals": [
+        "eggs"
+      ]
+    },
+    {
+      "id": "drinks",
+      "label": "Drinks",
+      "categoryId": "meal-type",
+      "reveals": [
+        "cocktail",
+        "coffee",
+        "mocktail",
+        "smoothie",
+        "tea"
+      ]
+    },
+    {
+      "id": "coffee",
+      "label": "Coffee Drinks",
+      "categoryId": "meal-type",
+      "reveals": []
+    },
+    {
+      "id": "tea",
+      "label": "Tea",
+      "categoryId": "meal-type",
+      "reveals": []
+    },
+    {
+      "id": "bruschetta",
+      "label": "Bruschetta",
+      "categoryId": "meal-type",
+      "reveals": []
+    },
+    {
+      "id": "spring-rolls",
+      "label": "Spring Rolls",
+      "categoryId": "meal-type",
+      "reveals": []
+    },
+    {
+      "id": "popcorn",
+      "label": "Popcorn",
+      "categoryId": "meal-type",
+      "reveals": []
+    },
+    {
+      "id": "pudding",
+      "label": "Puddings",
+      "categoryId": "meal-type",
+      "reveals": []
+    },
+    {
+      "id": "breakfast-bowl",
+      "label": "Breakfast Bowls",
+      "categoryId": "meal-type",
+      "reveals": []
+    },
+    {
+      "id": "bowls",
+      "label": "Bowls",
+      "categoryId": "meal-type",
+      "reveals": []
+    },
+    {
+      "id": "roasted-veg",
+      "label": "Roasted Vegetables",
+      "categoryId": "meal-type",
+      "reveals": []
+    },
+    {
+      "id": "chips-crisps",
+      "label": "Chips & Crisps",
+      "categoryId": "meal-type",
+      "reveals": []
+    },
+    {
+      "id": "energy-balls",
+      "label": "Energy Balls",
+      "categoryId": "meal-type",
+      "reveals": []
+    },
+    {
+      "id": "cocktail",
+      "label": "Cocktail",
+      "categoryId": "meal-type",
+      "reveals": [
+        "mocktail"
+      ]
+    },
+    {
+      "id": "mocktail",
+      "label": "Mocktail",
+      "categoryId": "meal-type",
+      "reveals": []
+    },
+    {
+      "id": "italian",
+      "label": "Italian",
+      "categoryId": "cuisine",
+      "reveals": [
+        "french",
+        "gnocchi",
+        "lasagna",
+        "mediterranean",
+        "pasta",
+        "risotto",
+        "sicilian",
+        "tiramisu",
+        "tomatoes",
+        "tuscan"
+      ]
+    },
+    {
+      "id": "chinese",
+      "label": "Chinese",
+      "categoryId": "cuisine",
+      "reveals": [
+        "cantonese",
+        "congee",
+        "dumplings",
+        "fried-rice",
+        "korean",
+        "noodles",
+        "rice",
+        "sichuan",
+        "sweet-sour",
+        "thai",
+        "tofu",
+        "vietnamese"
+      ]
+    },
+    {
+      "id": "mexican",
+      "label": "Mexican",
+      "categoryId": "cuisine",
+      "reveals": [
+        "avocado",
+        "beans",
+        "burritos",
+        "corn",
+        "enchiladas",
+        "guacamole",
+        "latin-american",
+        "mole",
+        "oaxacan",
+        "quesadilla",
+        "spanish",
+        "tacos",
+        "tamale"
+      ]
+    },
+    {
+      "id": "indian",
+      "label": "Indian",
+      "categoryId": "cuisine",
+      "reveals": [
+        "biryani",
+        "butter-chicken",
+        "chickpeas",
+        "dal",
+        "lentils",
+        "middle-eastern",
+        "naan",
+        "north-indian",
+        "pakistani",
+        "paneer",
+        "punjabi",
+        "rice",
+        "south-indian",
+        "sri-lankan",
+        "tandoori",
+        "tikka-masala"
+      ]
+    },
+    {
+      "id": "american",
+      "label": "American",
+      "categoryId": "cuisine",
+      "reveals": [
+        "british",
+        "caribbean",
+        "comfort-food",
+        "cornbread",
+        "fried-chicken",
+        "mac-and-cheese",
+        "southern"
+      ]
+    },
+    {
+      "id": "japanese",
+      "label": "Japanese",
+      "categoryId": "cuisine",
+      "reveals": [
+        "korean",
+        "miso",
+        "noodles",
+        "onigiri",
+        "ramen",
+        "rice",
+        "sushi",
+        "tempura",
+        "teriyaki",
+        "tofu",
+        "tonkatsu",
+        "udon"
+      ]
+    },
+    {
+      "id": "thai",
+      "label": "Thai",
+      "categoryId": "cuisine",
+      "reveals": [
+        "coconut",
+        "coconut-curry",
+        "noodles",
+        "pad-thai",
+        "rice",
+        "tom-yum",
+        "vietnamese"
+      ]
+    },
+    {
+      "id": "mediterranean",
+      "label": "Mediterranean",
+      "categoryId": "cuisine",
+      "reveals": [
+        "chickpeas",
+        "couscous",
+        "falafel",
+        "feta",
+        "greek",
+        "gyros",
+        "hummus",
+        "middle-eastern",
+        "moroccan",
+        "olive-oil",
+        "seafood",
+        "spanish",
+        "tabbouleh"
+      ]
+    },
+    {
+      "id": "french",
+      "label": "French",
+      "categoryId": "cuisine",
+      "reveals": [
+        "baking",
+        "british",
+        "cheese",
+        "coq-au-vin",
+        "crepes",
+        "croissant",
+        "german",
+        "provencal",
+        "ratatouille"
+      ]
+    },
+    {
+      "id": "korean",
+      "label": "Korean",
+      "categoryId": "cuisine",
+      "reveals": [
+        "beef",
+        "bibimbap",
+        "bulgogi",
+        "kimchi",
+        "korean-bbq",
+        "rice",
+        "tofu"
+      ]
+    },
+    {
+      "id": "vietnamese",
+      "label": "Vietnamese",
+      "categoryId": "cuisine",
+      "reveals": [
+        "banh-mi",
+        "herbs",
+        "noodles",
+        "pho",
+        "rice"
+      ]
+    },
+    {
+      "id": "latin-american",
+      "label": "Latin American",
+      "categoryId": "cuisine",
+      "reveals": [
+        "argentine",
+        "brazilian",
+        "cassava",
+        "empanada",
+        "peruvian"
+      ]
+    },
+    {
+      "id": "british",
+      "label": "British",
+      "categoryId": "cuisine",
+      "reveals": [
+        "comfort-food",
+        "fish-chips",
+        "scones",
+        "shepherds-pie"
+      ]
+    },
+    {
+      "id": "german",
+      "label": "German",
+      "categoryId": "cuisine",
+      "reveals": [
+        "pork",
+        "potatoes",
+        "sauerkraut",
+        "sausage",
+        "schnitzel",
+        "spaetzle"
+      ]
+    },
+    {
+      "id": "brazilian",
+      "label": "Brazilian",
+      "categoryId": "cuisine",
+      "reveals": [
+        "feijoada",
+        "pao-de-queijo"
+      ]
+    },
+    {
+      "id": "peruvian",
+      "label": "Peruvian",
+      "categoryId": "cuisine",
+      "reveals": [
+        "ceviche"
+      ]
+    },
+    {
+      "id": "argentine",
+      "label": "Argentine",
+      "categoryId": "cuisine",
+      "reveals": [
+        "asado"
+      ]
+    },
+    {
+      "id": "pakistani",
+      "label": "Pakistani",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "sri-lankan",
+      "label": "Sri Lankan",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "greek",
+      "label": "Greek",
+      "categoryId": "cuisine",
+      "reveals": [
+        "feta",
+        "gyros",
+        "lamb",
+        "moussaka",
+        "olive-oil",
+        "souvlaki",
+        "tzatziki"
+      ]
+    },
+    {
+      "id": "spanish",
+      "label": "Spanish",
+      "categoryId": "cuisine",
+      "reveals": [
+        "gazpacho",
+        "paella",
+        "portuguese",
+        "rice",
+        "seafood",
+        "tapas",
+        "tortilla-espanola"
+      ]
+    },
+    {
+      "id": "turkish",
+      "label": "Turkish",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "moroccan",
+      "label": "Moroccan",
+      "categoryId": "cuisine",
+      "reveals": [
+        "chickpeas",
+        "couscous",
+        "lamb",
+        "tagine"
+      ]
+    },
+    {
+      "id": "egyptian",
+      "label": "Egyptian",
+      "categoryId": "cuisine",
+      "reveals": [
+        "koshari"
+      ]
+    },
+    {
+      "id": "portuguese",
+      "label": "Portuguese",
+      "categoryId": "cuisine",
+      "reveals": [
+        "pastel-de-nata"
+      ]
+    },
+    {
+      "id": "sushi",
+      "label": "Sushi",
+      "categoryId": "cuisine",
+      "reveals": [
+        "rice",
+        "seafood"
+      ]
+    },
+    {
+      "id": "ramen",
+      "label": "Ramen",
+      "categoryId": "cuisine",
+      "reveals": [
+        "noodles"
+      ]
+    },
+    {
+      "id": "tacos",
+      "label": "Tacos",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "burritos",
+      "label": "Burritos",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "pad-thai",
+      "label": "Pad Thai",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "pho",
+      "label": "Pho",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "dumplings",
+      "label": "Dumplings",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "hummus",
+      "label": "Hummus",
+      "categoryId": "cuisine",
+      "reveals": [
+        "chickpeas"
+      ]
+    },
+    {
+      "id": "falafel",
+      "label": "Falafel",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "kebab",
+      "label": "Kebab",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "shawarma",
+      "label": "Shawarma",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "kimchi",
+      "label": "Kimchi",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "bibimbap",
+      "label": "Bibimbap",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "korean-bbq",
+      "label": "Korean BBQ",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "bulgogi",
+      "label": "Bulgogi",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "teriyaki",
+      "label": "Teriyaki",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "tempura",
+      "label": "Tempura",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "miso",
+      "label": "Miso Soup",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "udon",
+      "label": "Udon",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "butter-chicken",
+      "label": "Butter chicken",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "tikka-masala",
+      "label": "Tikka Masala",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "biryani",
+      "label": "Biryani",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "naan",
+      "label": "Naan",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "tandoori",
+      "label": "Tandoori",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "dal",
+      "label": "Dal",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "dosa",
+      "label": "Dosa",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "idli",
+      "label": "Idli",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "paella",
+      "label": "Paella",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "tapas",
+      "label": "Tapas",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "gazpacho",
+      "label": "Gazpacho",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "tabbouleh",
+      "label": "Tabbouleh",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "mezze",
+      "label": "Mezze",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "baba-ganoush",
+      "label": "Baba ganoush",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "couscous",
+      "label": "Couscous",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "tagine",
+      "label": "Tagine",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "guacamole",
+      "label": "Guacamole",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "quesadilla",
+      "label": "Quesadilla",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "enchiladas",
+      "label": "Enchiladas",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "mac-and-cheese",
+      "label": "Mac & Cheese",
+      "categoryId": "cuisine",
+      "reveals": [
+        "cheese",
+        "pasta"
+      ]
+    },
+    {
+      "id": "fried-chicken",
+      "label": "Fried Chicken",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "southern",
+      "label": "Southern (US)",
+      "categoryId": "cuisine",
+      "reveals": [
+        "cajun"
+      ]
+    },
+    {
+      "id": "cajun",
+      "label": "Cajun & Creole",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "cornbread",
+      "label": "Cornbread",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "comfort-food",
+      "label": "Comfort Food",
+      "categoryId": "cuisine",
+      "reveals": [
+        "mac-and-cheese"
+      ]
+    },
+    {
+      "id": "caribbean",
+      "label": "Caribbean",
+      "categoryId": "cuisine",
+      "reveals": [
+        "beans",
+        "coconut",
+        "rice"
+      ]
+    },
+    {
+      "id": "fish-chips",
+      "label": "Fish & Chips",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "shepherds-pie",
+      "label": "Shepherd's Pie",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "scones",
+      "label": "Scones",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "croissant",
+      "label": "Croissant",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "crepes",
+      "label": "Crepes",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "tiramisu",
+      "label": "Tiramisu",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "ratatouille",
+      "label": "Ratatouille",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "coq-au-vin",
+      "label": "Coq au Vin",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "provencal",
+      "label": "Provencal",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "sicilian",
+      "label": "Sicilian",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "tuscan",
+      "label": "Tuscan",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "north-indian",
+      "label": "North Indian",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "south-indian",
+      "label": "South Indian",
+      "categoryId": "cuisine",
+      "reveals": [
+        "dosa",
+        "idli"
+      ]
+    },
+    {
+      "id": "punjabi",
+      "label": "Punjabi",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "coconut-curry",
+      "label": "Coconut Curry",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "sweet-sour",
+      "label": "Sweet & Sour",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "char-siu",
+      "label": "BBQ pork (char siu)",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "mapo-tofu",
+      "label": "Mapo tofu",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "cantonese",
+      "label": "Cantonese",
+      "categoryId": "cuisine",
+      "reveals": [
+        "char-siu"
+      ]
+    },
+    {
+      "id": "sichuan",
+      "label": "Sichuan",
+      "categoryId": "cuisine",
+      "reveals": [
+        "mapo-tofu"
+      ]
+    },
+    {
+      "id": "congee",
+      "label": "Rice porridge (congee)",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "tonkatsu",
+      "label": "Pork cutlet (tonkatsu)",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "onigiri",
+      "label": "Rice ball (onigiri)",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "tom-yum",
+      "label": "Tom Yum",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "banh-mi",
+      "label": "Banh Mi",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "schnitzel",
+      "label": "Schnitzel",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "spaetzle",
+      "label": "Spaetzle",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "sauerkraut",
+      "label": "Sauerkraut",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "tortilla-espanola",
+      "label": "Spanish Tortilla",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "tzatziki",
+      "label": "Tzatziki",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "gyros",
+      "label": "Gyros",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "souvlaki",
+      "label": "Souvlaki",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "moussaka",
+      "label": "Moussaka",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "levantine",
+      "label": "Levantine",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "middle-eastern",
+      "label": "Middle Eastern",
+      "categoryId": "cuisine",
+      "reveals": [
+        "baba-ganoush",
+        "chickpeas",
+        "couscous",
+        "egyptian",
+        "falafel",
+        "hummus",
+        "kebab",
+        "lamb",
+        "levantine",
+        "mezze",
+        "rice",
+        "shawarma",
+        "tabbouleh",
+        "turkish"
+      ]
+    },
+    {
+      "id": "oaxacan",
+      "label": "Oaxacan",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "mole",
+      "label": "Mole",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "tamale",
+      "label": "Tamale",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "empanada",
+      "label": "Empanada",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "ceviche",
+      "label": "Ceviche",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "feijoada",
+      "label": "Feijoada (bean stew)",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "asado",
+      "label": "Asado (barbecue)",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "pastel-de-nata",
+      "label": "Custard tart",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "pao-de-queijo",
+      "label": "Cheese bread",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "koshari",
+      "label": "Koshari",
+      "categoryId": "cuisine",
+      "reveals": []
+    },
+    {
+      "id": "chicken",
+      "label": "Chicken",
+      "categoryId": "ingredient",
+      "reveals": [
+        "chicken-breast",
+        "chicken-thigh",
+        "wings"
+      ]
+    },
+    {
+      "id": "beef",
+      "label": "Beef",
+      "categoryId": "ingredient",
+      "reveals": [
+        "brisket",
+        "ground-beef",
+        "meatballs",
+        "mince",
+        "steak"
+      ]
+    },
+    {
+      "id": "pork",
+      "label": "Pork",
+      "categoryId": "ingredient",
+      "reveals": [
+        "bacon",
+        "ham",
+        "pork-chop",
+        "pulled-pork",
+        "sausage"
+      ]
+    },
+    {
+      "id": "eggs",
+      "label": "Eggs",
+      "categoryId": "ingredient",
+      "reveals": [
+        "frittata",
+        "omelette",
+        "scrambled-eggs"
+      ]
+    },
+    {
+      "id": "cheese",
+      "label": "Cheese",
+      "categoryId": "ingredient",
+      "reveals": [
+        "cheddar",
+        "feta",
+        "halloumi",
+        "mozzarella",
+        "paneer"
+      ]
+    },
+    {
+      "id": "pasta",
+      "label": "Pasta",
+      "categoryId": "ingredient",
+      "reveals": [
+        "gnocchi",
+        "lasagna",
+        "penne",
+        "ravioli",
+        "spaghetti"
+      ]
+    },
+    {
+      "id": "vegetables",
+      "label": "Vegetables",
+      "categoryId": "ingredient",
+      "reveals": [
+        "broccoli",
+        "carrots",
+        "cauliflower",
+        "eggplant",
+        "fruit",
+        "herbs",
+        "leafy-greens",
+        "mushrooms",
+        "peppers",
+        "potatoes",
+        "spinach",
+        "tomatoes",
+        "zucchini"
+      ]
+    },
+    {
+      "id": "fish",
+      "label": "Fish",
+      "categoryId": "ingredient",
+      "reveals": [
+        "cod",
+        "salmon",
+        "seafood",
+        "tuna"
+      ]
+    },
+    {
+      "id": "rice",
+      "label": "Rice",
+      "categoryId": "ingredient",
+      "reveals": [
+        "fried-rice",
+        "rice-bowl",
+        "risotto"
+      ]
+    },
+    {
+      "id": "potatoes",
+      "label": "Potatoes",
+      "categoryId": "ingredient",
+      "reveals": [
+        "fries",
+        "mashed-potatoes",
+        "sweet-potato"
+      ]
+    },
+    {
+      "id": "tomatoes",
+      "label": "Tomatoes",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "chicken-breast",
+      "label": "Chicken Breast",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "ground-beef",
+      "label": "Ground Beef",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "chicken-thigh",
+      "label": "Chicken Thigh",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "salmon",
+      "label": "Salmon",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "shrimp",
+      "label": "Shrimp",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "prawns",
+      "label": "Prawns",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "tuna",
+      "label": "Tuna",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "bacon",
+      "label": "Bacon",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "sausage",
+      "label": "Sausage",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "ham",
+      "label": "Ham",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "steak",
+      "label": "Steak",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "lamb",
+      "label": "Lamb",
+      "categoryId": "ingredient",
+      "reveals": [
+        "lamb-chops",
+        "lamb-curry"
+      ]
+    },
+    {
+      "id": "lamb-chops",
+      "label": "Lamb Chops",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "lamb-curry",
+      "label": "Lamb Curry",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "mushrooms",
+      "label": "Mushrooms",
+      "categoryId": "ingredient",
+      "reveals": [
+        "risotto"
+      ]
+    },
+    {
+      "id": "spinach",
+      "label": "Spinach",
+      "categoryId": "ingredient",
+      "reveals": [
+        "leafy-greens"
+      ]
+    },
+    {
+      "id": "broccoli",
+      "label": "Broccoli",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "carrots",
+      "label": "Carrots",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "cauliflower",
+      "label": "Cauliflower",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "peppers",
+      "label": "Peppers",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "corn",
+      "label": "Corn",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "avocado",
+      "label": "Avocado",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "tofu",
+      "label": "Tofu",
+      "categoryId": "ingredient",
+      "reveals": [
+        "buddha-bowl",
+        "tempeh"
+      ]
+    },
+    {
+      "id": "beans",
+      "label": "Beans",
+      "categoryId": "ingredient",
+      "reveals": [
+        "black-beans",
+        "chickpeas",
+        "kidney-beans",
+        "lentils"
+      ]
+    },
+    {
+      "id": "lentils",
+      "label": "Lentils",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "chickpeas",
+      "label": "Chickpeas",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "noodles",
+      "label": "Noodles",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "spaghetti",
+      "label": "Spaghetti",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "penne",
+      "label": "Penne",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "lasagna",
+      "label": "Lasagna",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "risotto",
+      "label": "Risotto",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "gnocchi",
+      "label": "Gnocchi",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "ravioli",
+      "label": "Ravioli",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "fried-rice",
+      "label": "Fried Rice",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "mozzarella",
+      "label": "Mozzarella",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "cheddar",
+      "label": "Cheddar",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "feta",
+      "label": "Feta",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "paneer",
+      "label": "Paneer",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "halloumi",
+      "label": "Halloumi",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "chocolate",
+      "label": "Chocolate",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "fruit",
+      "label": "Fruit",
+      "categoryId": "ingredient",
+      "reveals": [
+        "apple",
+        "banana",
+        "berries",
+        "lemon"
+      ]
+    },
+    {
+      "id": "apple",
+      "label": "Apple",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "banana",
+      "label": "Banana",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "berries",
+      "label": "Berries",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "lemon",
+      "label": "Lemon",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "coconut",
+      "label": "Coconut",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "herbs",
+      "label": "Fresh Herbs",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "olive-oil",
+      "label": "Olive Oil",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "eggplant",
+      "label": "Eggplant",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "zucchini",
+      "label": "Zucchini",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "sweet-potato",
+      "label": "Sweet Potato",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "mashed-potatoes",
+      "label": "Mashed Potatoes",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "fries",
+      "label": "Fries",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "cod",
+      "label": "Cod",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "seafood",
+      "label": "Seafood",
+      "categoryId": "ingredient",
+      "reveals": [
+        "cod",
+        "crab",
+        "mussels",
+        "prawns",
+        "salmon",
+        "shrimp",
+        "squid",
+        "tuna"
+      ]
+    },
+    {
+      "id": "crab",
+      "label": "Crab",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "mussels",
+      "label": "Mussels",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "squid",
+      "label": "Squid & Calamari",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "duck",
+      "label": "Duck",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "turkey",
+      "label": "Turkey",
+      "categoryId": "ingredient",
+      "reveals": [
+        "ground-turkey"
+      ]
+    },
+    {
+      "id": "ground-turkey",
+      "label": "Ground Turkey",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "pork-chop",
+      "label": "Pork Chop",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "pulled-pork",
+      "label": "Pulled Pork",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "brisket",
+      "label": "Brisket",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "wings",
+      "label": "Chicken Wings",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "meatballs",
+      "label": "Meatballs",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "mince",
+      "label": "Mince",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "scrambled-eggs",
+      "label": "Scrambled Eggs",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "omelette",
+      "label": "Omelette",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "frittata",
+      "label": "Frittata",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "black-beans",
+      "label": "Black Beans",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "kidney-beans",
+      "label": "Kidney Beans",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "quinoa",
+      "label": "Quinoa",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "tempeh",
+      "label": "Tempeh",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "cassava",
+      "label": "Cassava",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "buddha-bowl",
+      "label": "Buddha Bowl",
+      "categoryId": "ingredient",
+      "reveals": [
+        "quinoa"
+      ]
+    },
+    {
+      "id": "rice-bowl",
+      "label": "Rice Bowls",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "leafy-greens",
+      "label": "Leafy Greens",
+      "categoryId": "ingredient",
+      "reveals": []
+    },
+    {
+      "id": "weeknight",
+      "label": "Weeknight",
+      "categoryId": "occasion",
+      "reveals": [
+        "30-minute",
+        "budget",
+        "kids",
+        "meal-prep",
+        "one-pot",
+        "quick"
+      ]
+    },
+    {
+      "id": "party",
+      "label": "Party",
+      "categoryId": "occasion",
+      "reveals": [
+        "brunch-party",
+        "date-night",
+        "dinner-party",
+        "potluck"
+      ]
+    },
+    {
+      "id": "bbq",
+      "label": "BBQ",
+      "categoryId": "occasion",
+      "reveals": [
+        "grilling",
+        "skewers",
+        "summer"
+      ]
+    },
+    {
+      "id": "festival",
+      "label": "Holiday",
+      "categoryId": "occasion",
+      "reveals": [
+        "christmas",
+        "day-of-the-dead",
+        "diwali",
+        "easter",
+        "eid",
+        "festa-junina",
+        "halloween",
+        "lunar-new-year",
+        "new-year",
+        "ramadan",
+        "thanksgiving",
+        "valentines"
+      ]
+    },
+    {
+      "id": "summer",
+      "label": "Summer",
+      "categoryId": "occasion",
+      "reveals": [
+        "grilling",
+        "picnic"
+      ]
+    },
+    {
+      "id": "winter",
+      "label": "Winter",
+      "categoryId": "occasion",
+      "reveals": []
+    },
+    {
+      "id": "spring",
+      "label": "Spring",
+      "categoryId": "occasion",
+      "reveals": [
+        "asparagus"
+      ]
+    },
+    {
+      "id": "autumn",
+      "label": "Autumn",
+      "categoryId": "occasion",
+      "reveals": [
+        "pumpkin"
+      ]
+    },
+    {
+      "id": "christmas",
+      "label": "Christmas",
+      "categoryId": "occasion",
+      "reveals": [
+        "holiday-baking"
+      ]
+    },
+    {
+      "id": "halloween",
+      "label": "Halloween",
+      "categoryId": "occasion",
+      "reveals": [
+        "treats"
+      ]
+    },
+    {
+      "id": "thanksgiving",
+      "label": "Thanksgiving",
+      "categoryId": "occasion",
+      "reveals": [
+        "holiday-baking"
+      ]
+    },
+    {
+      "id": "easter",
+      "label": "Easter",
+      "categoryId": "occasion",
+      "reveals": [
+        "holiday-baking"
+      ]
+    },
+    {
+      "id": "new-year",
+      "label": "New Year's Eve",
+      "categoryId": "occasion",
+      "reveals": []
+    },
+    {
+      "id": "valentines",
+      "label": "Valentine's Day",
+      "categoryId": "occasion",
+      "reveals": []
+    },
+    {
+      "id": "date-night",
+      "label": "Date Night",
+      "categoryId": "occasion",
+      "reveals": []
+    },
+    {
+      "id": "dinner-party",
+      "label": "Dinner Party",
+      "categoryId": "occasion",
+      "reveals": []
+    },
+    {
+      "id": "brunch-party",
+      "label": "Brunch Party",
+      "categoryId": "occasion",
+      "reveals": []
+    },
+    {
+      "id": "picnic",
+      "label": "Picnic",
+      "categoryId": "occasion",
+      "reveals": []
+    },
+    {
+      "id": "potluck",
+      "label": "Potluck",
+      "categoryId": "occasion",
+      "reveals": []
+    },
+    {
+      "id": "kids",
+      "label": "Kid-Friendly",
+      "categoryId": "occasion",
+      "reveals": []
+    },
+    {
+      "id": "meal-prep",
+      "label": "Meal Prep",
+      "categoryId": "occasion",
+      "reveals": [
+        "batch-cooking",
+        "bento",
+        "budget",
+        "one-pot"
+      ]
+    },
+    {
+      "id": "batch-cooking",
+      "label": "Batch cooking",
+      "categoryId": "occasion",
+      "reveals": []
+    },
+    {
+      "id": "quick",
+      "label": "Quick & Easy",
+      "categoryId": "occasion",
+      "reveals": [
+        "15-minute",
+        "30-minute",
+        "5-ingredient",
+        "no-cook",
+        "one-pan",
+        "sheet-pan"
+      ]
+    },
+    {
+      "id": "30-minute",
+      "label": "30-Minute Meals",
+      "categoryId": "occasion",
+      "reveals": [
+        "one-pan",
+        "quick"
+      ]
+    },
+    {
+      "id": "holiday-baking",
+      "label": "Holiday Baking",
+      "categoryId": "occasion",
+      "reveals": [
+        "baking"
+      ]
+    },
+    {
+      "id": "treats",
+      "label": "Treats",
+      "categoryId": "occasion",
+      "reveals": []
+    },
+    {
+      "id": "diwali",
+      "label": "Diwali",
+      "categoryId": "occasion",
+      "reveals": []
+    },
+    {
+      "id": "eid",
+      "label": "Eid",
+      "categoryId": "occasion",
+      "reveals": []
+    },
+    {
+      "id": "ramadan",
+      "label": "Ramadan",
+      "categoryId": "occasion",
+      "reveals": []
+    },
+    {
+      "id": "lunar-new-year",
+      "label": "Lunar New Year",
+      "categoryId": "occasion",
+      "reveals": []
+    },
+    {
+      "id": "day-of-the-dead",
+      "label": "Day of the Dead",
+      "categoryId": "occasion",
+      "reveals": []
+    },
+    {
+      "id": "festa-junina",
+      "label": "Festa Junina",
+      "categoryId": "occasion",
+      "reveals": []
+    },
+    {
+      "id": "bento",
+      "label": "Bento / lunchbox",
+      "categoryId": "occasion",
+      "reveals": []
+    },
+    {
+      "id": "asparagus",
+      "label": "Asparagus",
+      "categoryId": "occasion",
+      "reveals": []
+    },
+    {
+      "id": "pumpkin",
+      "label": "Pumpkin",
+      "categoryId": "occasion",
+      "reveals": []
+    },
+    {
+      "id": "baking",
+      "label": "Baking",
+      "categoryId": "method",
+      "reveals": [
+        "roasting",
+        "sheet-pan"
+      ]
+    },
+    {
+      "id": "grilling",
+      "label": "Grilling & BBQ",
+      "categoryId": "method",
+      "reveals": [
+        "grilled-veg",
+        "skewers",
+        "sous-vide"
+      ]
+    },
+    {
+      "id": "frying",
+      "label": "Frying",
+      "categoryId": "method",
+      "reveals": [
+        "deep-frying"
+      ]
+    },
+    {
+      "id": "air-fryer",
+      "label": "Air Fryer",
+      "categoryId": "method",
+      "reveals": [
+        "crispy"
+      ]
+    },
+    {
+      "id": "slow-cooker",
+      "label": "Slow Cooker",
+      "categoryId": "method",
+      "reveals": [
+        "braising",
+        "instant-pot",
+        "make-ahead",
+        "pulled"
+      ]
+    },
+    {
+      "id": "one-pot",
+      "label": "One-Pot",
+      "categoryId": "method",
+      "reveals": [
+        "instant-pot",
+        "one-pan",
+        "sheet-pan"
+      ]
+    },
+    {
+      "id": "steaming",
+      "label": "Steaming",
+      "categoryId": "method",
+      "reveals": []
+    },
+    {
+      "id": "no-cook",
+      "label": "No-Cook",
+      "categoryId": "method",
+      "reveals": [
+        "overnight-oats",
+        "raw"
+      ]
+    },
+    {
+      "id": "roasting",
+      "label": "Roasting",
+      "categoryId": "method",
+      "reveals": []
+    },
+    {
+      "id": "deep-frying",
+      "label": "Deep-frying",
+      "categoryId": "method",
+      "reveals": []
+    },
+    {
+      "id": "instant-pot",
+      "label": "Instant Pot / Pressure Cooker",
+      "categoryId": "method",
+      "reveals": []
+    },
+    {
+      "id": "sheet-pan",
+      "label": "Sheet Pan / Tray Bake",
+      "categoryId": "method",
+      "reveals": [
+        "one-pan"
+      ]
+    },
+    {
+      "id": "one-pan",
+      "label": "One-Pan",
+      "categoryId": "method",
+      "reveals": []
+    },
+    {
+      "id": "braising",
+      "label": "Braising",
+      "categoryId": "method",
+      "reveals": []
+    },
+    {
+      "id": "skewers",
+      "label": "Skewers & Kebabs",
+      "categoryId": "method",
+      "reveals": []
+    },
+    {
+      "id": "grilled-veg",
+      "label": "Grilled Vegetables",
+      "categoryId": "method",
+      "reveals": []
+    },
+    {
+      "id": "crispy",
+      "label": "Crispy",
+      "categoryId": "method",
+      "reveals": []
+    },
+    {
+      "id": "raw",
+      "label": "Raw / No-Bake",
+      "categoryId": "method",
+      "reveals": []
+    },
+    {
+      "id": "sous-vide",
+      "label": "Sous Vide",
+      "categoryId": "method",
+      "reveals": []
+    },
+    {
+      "id": "budget",
+      "label": "Budget-Friendly",
+      "categoryId": "method",
+      "reveals": [
+        "5-ingredient",
+        "make-ahead",
+        "pantry"
+      ]
+    },
+    {
+      "id": "make-ahead",
+      "label": "Make-Ahead",
+      "categoryId": "method",
+      "reveals": [
+        "freezer-friendly"
+      ]
+    },
+    {
+      "id": "freezer-friendly",
+      "label": "Freezer-Friendly",
+      "categoryId": "method",
+      "reveals": []
+    },
+    {
+      "id": "overnight-oats",
+      "label": "Overnight Oats",
+      "categoryId": "method",
+      "reveals": []
+    },
+    {
+      "id": "pulled",
+      "label": "Pulled / Shredded",
+      "categoryId": "method",
+      "reveals": []
+    },
+    {
+      "id": "15-minute",
+      "label": "15-Minute Meals",
+      "categoryId": "method",
+      "reveals": []
+    },
+    {
+      "id": "5-ingredient",
+      "label": "5-Ingredient",
+      "categoryId": "method",
+      "reveals": [
+        "budget"
+      ]
+    },
+    {
+      "id": "pantry",
+      "label": "Pantry Staples",
+      "categoryId": "method",
+      "reveals": []
+    }
+  ]
+}

--- a/web-client/tests/e2e/smoke.spec.ts
+++ b/web-client/tests/e2e/smoke.spec.ts
@@ -35,7 +35,7 @@ test('login -> generate -> open recipe -> log out', async ({page}) => {
 	await page.keyboard.press('Enter')
 
 	await expect(page).toHaveURL(/\/generate$/)
-	await page.getByPlaceholder(/What do you want to cook/i).fill('pasta')
+	await page.getByPlaceholder(/Type what you think/i).fill('pasta')
 	await page.getByRole('button', {name: 'Generate'}).click()
 
 	await page.getByRole('button', {name: /Tomato Pasta/}).click()

--- a/web-client/tests/e2e/tag-search.spec.ts
+++ b/web-client/tests/e2e/tag-search.spec.ts
@@ -1,0 +1,57 @@
+import {expect, test} from '@playwright/test'
+
+const recipe = {
+	id: 1,
+	title: 'Tomato Pasta',
+	portions: 2,
+	ingredients: [{name: 'tomato', quantity: 4, unit: 'pcs'}],
+	instructions: ['boil pasta', 'add sauce'],
+	nutrients: {calories: 500, protein: 20, fat: 10, carbs: 60},
+}
+
+test('tag selector reveals nested tags and folds the selection into the prompt', async ({page}) => {
+	// Arrange
+	await page.route('**/api/v1/users/login', (route) =>
+		route.fulfill({status: 200, contentType: 'application/json', body: JSON.stringify({token: 'tok'})}),
+	)
+	await page.route('**/api/v1/users/profile', (route) =>
+		route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({username: 'demo', preferences: {}}),
+		}),
+	)
+	let recipesRequestBody: string | null = null
+	await page.route('**/api/v1/ai/recipes', (route) => {
+		recipesRequestBody = route.request().postData()
+		route.fulfill({status: 200, contentType: 'application/json', body: JSON.stringify([recipe])})
+	})
+
+	// Act & Assert
+	await page.goto('login')
+	await page.getByLabel('Username').fill('demo')
+	await page.getByLabel('Password', {exact: true}).first().fill('test')
+	await page.keyboard.press('Enter')
+	await expect(page).toHaveURL(/\/generate$/)
+
+	// a default tag is shown, but its nested reveal only appears once the parent is selected
+	const dinner = page.getByRole('button', {name: 'Dinner', exact: true})
+	await expect(dinner).toBeVisible()
+	await expect(page.getByRole('button', {name: 'Curry', exact: true})).toHaveCount(0)
+
+	await dinner.click()
+	await expect(page.getByRole('button', {name: 'Curry', exact: true})).toBeVisible()
+
+	// the free-text input and the selected tag both feed into the generation request
+	await page.getByPlaceholder(/Type what you think/i).fill('quick weeknight meal')
+	await page.getByRole('button', {name: 'Generate'}).click()
+
+	await expect(page).toHaveURL(/\/generate\/results$/)
+	await expect(page.getByRole('button', {name: /Tomato Pasta/})).toBeVisible()
+
+	expect(recipesRequestBody).not.toBeNull()
+	const sentPrompt = JSON.parse(recipesRequestBody!).prompt as string
+	expect(sentPrompt).toContain('quick weeknight meal')
+	expect(sentPrompt).toContain('Preferences:')
+	expect(sentPrompt).toContain('Dinner')
+})

--- a/web-client/tests/pages/GeneratePage.test.tsx
+++ b/web-client/tests/pages/GeneratePage.test.tsx
@@ -3,7 +3,7 @@ import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, vi } from 'vitest'
 import type { components } from '../../src/api'
-import { GeneratePage } from '../../src/pages/GeneratePage'
+import { GenerateFlow, GeneratePage, GenerateResultsPage } from '../../src/pages/GeneratePage'
 import { jsonResponse, renderWithProviders } from '../utils'
 
 type Recipe = components['schemas']['Recipe']
@@ -28,12 +28,15 @@ afterEach(() => {
   vi.unstubAllGlobals()
 })
 
-function render() {
+function render(route = '/generate') {
   renderWithProviders(
     <Routes>
-      <Route path="/generate" element={<GeneratePage />} />
+      <Route path="/generate" element={<GenerateFlow />}>
+        <Route index element={<GeneratePage />} />
+        <Route path="results" element={<GenerateResultsPage />} />
+      </Route>
     </Routes>,
-    { route: '/generate', token: { value: 'tkn', username: 'alice' } },
+    { route, token: { value: 'tkn', username: 'alice' } },
   )
 }
 
@@ -41,7 +44,7 @@ describe('GeneratePage', () => {
   it('restores previously generated recipes from sessionStorage', () => {
     sessionStorage.setItem('generated_recipes', JSON.stringify([recipe]))
 
-    render()
+    render('/generate/results')
 
     expect(screen.getByText('Tomato Pasta')).toBeInTheDocument()
     expect(screen.getByText('2 portions')).toBeInTheDocument()
@@ -52,21 +55,21 @@ describe('GeneratePage', () => {
     const user = userEvent.setup()
     render()
 
-    await user.type(screen.getByPlaceholderText(/What do you want to cook/i), 'anything')
+    await user.type(screen.getByPlaceholderText(/Type what you think/i), 'anything')
     await user.click(screen.getByRole('button', { name: 'Generate' }))
 
     expect(await screen.findByText('No recipes returned.')).toBeInTheDocument()
   })
 
-  it('shows a server error and clears the loading state', async () => {
+  it('shows a server error on the results page', async () => {
     fetchMock.mockResolvedValueOnce(jsonResponse({ message: 'GenAI down' }, { status: 503 }))
     const user = userEvent.setup()
     render()
 
-    await user.type(screen.getByPlaceholderText(/What do you want to cook/i), 'pasta')
+    await user.type(screen.getByPlaceholderText(/Type what you think/i), 'pasta')
     await user.click(screen.getByRole('button', { name: 'Generate' }))
 
     expect(await screen.findByText('Error: GenAI down')).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Generate' })).toBeEnabled()
+    expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument()
   })
 })

--- a/web-client/tests/pages/RecipePage.test.tsx
+++ b/web-client/tests/pages/RecipePage.test.tsx
@@ -1,4 +1,5 @@
-import {Route, Routes} from 'react-router-dom'
+import {useState} from 'react'
+import {Outlet, Route, Routes} from 'react-router-dom'
 import {screen} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import {afterEach, beforeEach, vi} from 'vitest'
@@ -28,12 +29,18 @@ afterEach(() => {
 	vi.unstubAllGlobals()
 })
 
+// mirrors the GenerateFlow layout that holds the shared recipe list
+function GenerateContext({recipes}: {recipes: Recipe[]}) {
+	const [list, setList] = useState(recipes)
+	return <Outlet context={{recipes: list, setRecipes: setList}}/>
+}
+
 function renderGeneratedRecipe(index = 0, recipes: Recipe[] = [a, b]) {
-	sessionStorage.setItem('generated_recipes', JSON.stringify(recipes))
 	renderWithProviders(
 		<Routes>
-			<Route path="/generate" element={<div>generate page</div>}/>
-			<Route path="/generate/recipe" element={<RecipePage/>}/>
+			<Route path="/generate" element={<GenerateContext recipes={recipes}/>}>
+				<Route path="recipe" element={<RecipePage/>}/>
+			</Route>
 		</Routes>,
 		{
 			route: {pathname: '/generate/recipe', state: {index}},

--- a/web-client/tsconfig.app.json
+++ b/web-client/tsconfig.app.json
@@ -10,6 +10,7 @@
     /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
     "verbatimModuleSyntax": true,
     "moduleDetection": "force",
     "noEmit": true,


### PR DESCRIPTION
## Summary
- Add a recipe tag taxonomy (`recipeTags.json`, 5 facets / progressive-disclosure reveals) and a reusable `TagSelector` component that tints chips by reveal depth.
- Render the selector on the `/generate` options page and fold the chosen tags into the prompt (no tag endpoint yet).
- Split generation into two pages: `/generate` (options) and `/generate/results` (list), wired through a `GenerateFlow` layout route so an in-flight request survives the navigation.
- Add a direction-aware slide transition between the pages, a search recap with an **Edit** shortcut on the results page, and a **View recipes** shortcut on the options page.

## How the tag structure was built
- **Parallel research + merge:** several independent Claude Code agents crawled mainstream recipe portals over two rounds (round 1 English, round 2 multilingual for de-biasing), each returning a facets/tags/reveals taxonomy that was then merged.
- **Curation:** kept broadly-representative cuisines/dishes and dropped single-source hyperlocal long-tail entries, landing at ~316 tags across 5 facets.
- **Validated invariants:** every merge is checked programmatically — full reachability, no dangling refs, valid facets, no duplicate ids, English/ASCII labels, and downward-only cross-facet reveals (so a lower selection never injects chips above it).

## Improvement Ideas for later
- a dedicated Tag Generation Service that takes the profile, the tags and the current prompt and suggests other tag options
- adding tags to the API spec rather than injecting them into the prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)