### PR TITLE
Fix prod deploy: switch host to Docker Compose v2 (BuildKit)

### DIFF
--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -17,17 +17,11 @@
       args:
         creates: /usr/bin/docker
 
-    - name: Check if docker-compose exists
-      stat:
-        path: /usr/local/bin/docker-compose
-      register: compose_bin
-
-    - name: Install legacy docker-compose
-      get_url:
-        url: https://github.com/docker/compose/releases/latest/download/docker-compose-Linux-x86_64
-        dest: /usr/local/bin/docker-compose
-        mode: '0755'
-      when: not compose_bin.stat.exists
+    - name: Ensure Docker Compose v2 plugin is installed
+      apt:
+        name: docker-compose-plugin
+        state: present
+        update_cache: yes
 
     - name: Force clean any untracked blocking files
       command: git clean -fdx
@@ -56,7 +50,7 @@
         mode: '0644'
 
     - name: Ensure previous containers are stopped
-      command: /usr/local/bin/docker-compose down
+      command: docker compose down
       args:
         chdir: /var/www/app/infra
       ignore_errors: yes
@@ -64,7 +58,7 @@
     - name: Attempt Docker Deployment
       block:
         - name: Bring up application with Docker Compose
-          command: /usr/local/bin/docker-compose up -d --build
+          command: docker compose up -d --build
           args:
             chdir: /var/www/app/infra
           register: compose_output


### PR DESCRIPTION
## Problem

The **Deploy to Production** workflow fails recently. The host uses old docker-compose v1, whose builder can't handle these lines in the Spring Dockerfile:

```
the --mount option requires BuildKit
```

So the Spring image build fails and the deploy aborts.

## Fix

Switch the host to **Docker Compose v2** (`docker compose`), which uses BuildKit by default:
- Install `docker-compose-plugin` instead of the legacy v1 binary.
- Call `docker compose` for `down`/`up`.

No Dockerfile or CI changes. Only verifiable once it deploys on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)