### PR TITLE
Fix prod deploy: install Compose v2 as CLI plugin binary

### DIFF
--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -17,11 +17,17 @@
       args:
         creates: /usr/bin/docker
 
-    - name: Ensure Docker Compose v2 plugin is installed
-      apt:
-        name: docker-compose-plugin
-        state: present
-        update_cache: yes
+    - name: Ensure docker cli-plugins directory exists
+      file:
+        path: /usr/local/lib/docker/cli-plugins
+        state: directory
+        mode: '0755'
+
+    - name: Install Docker Compose v2 as a CLI plugin
+      get_url:
+        url: https://github.com/docker/compose/releases/latest/download/docker-compose-linux-x86_64
+        dest: /usr/local/lib/docker/cli-plugins/docker-compose
+        mode: '0755'
 
     - name: Force clean any untracked blocking files
       command: git clean -fdx


### PR DESCRIPTION
## Problem

Follow-up to #96. That fix cleared the BuildKit build error, but the deploy now fails one step earlier:

```
No package matching 'docker-compose-plugin' is available
```

The host has no Docker apt repo configured (the `get.docker.com` step is skipped because Docker is already installed), so `apt` can't find the plugin.

## Fix

Install the Compose v2 binary directly into the docker cli-plugins dir instead of via apt. `docker compose` then works regardless of apt repo state, with BuildKit on by default.

## Verification

Tested the mechanism in a clean `ubuntu:22.04` container mirroring the host (Docker present, Compose absent):

- **Before:** `docker compose version` → `unknown command: docker compose`
- Ran the exact playbook steps (mkdir cli-plugins dir → download `docker-compose-linux-x86_64` → chmod 0755)
- **After:** `docker compose version` → reports a working v2 Compose

This reproduces the host's exact failure state and confirms the download URL is valid and that placing the binary makes `docker compose` resolve. The full SSH/Ansible run against the Azure VM is only exercised on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)