### PR TITLE
Fix prod deploy: install buildx so Compose v2 uses BuildKit

### DIFF
--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -29,6 +29,21 @@
         dest: /usr/local/lib/docker/cli-plugins/docker-compose
         mode: '0755'
 
+    # Compose v2 only builds with BuildKit when the buildx plugin is present;
+    # without it, it silently falls back to the classic builder, which rejects
+    # the `RUN --mount=type=cache` lines in the Spring Dockerfile.
+    - name: Get latest Docker Buildx release tag
+      uri:
+        url: https://api.github.com/repos/docker/buildx/releases/latest
+        return_content: yes
+      register: buildx_release
+
+    - name: Install Docker Buildx as a CLI plugin
+      get_url:
+        url: "https://github.com/docker/buildx/releases/download/{{ buildx_release.json.tag_name }}/buildx-{{ buildx_release.json.tag_name }}.linux-amd64"
+        dest: /usr/local/lib/docker/cli-plugins/docker-buildx
+        mode: '0755'
+
     - name: Force clean any untracked blocking files
       command: git clean -fdx
       args:


### PR DESCRIPTION
## Problem

Final piece of the prod-deploy fix (after #96 and #97). Compose v2 now runs, but the Spring image **still** fails on `RUN --mount=type=cache`:

```
the --mount option requires BuildKit
```

Compose v2 only builds with BuildKit when the **buildx** plugin is present. The host has neither compose nor buildx, so compose silently fell back to the classic builder — confirmed by `LABEL com.docker.compose.image.builder=classic` in the build output.

## Fix

Install the buildx CLI plugin alongside compose (its release asset is version-stamped, so the tag is fetched via the GitHub API).

## Verification

Tested end-to-end in a privileged container mirroring the host (docker present, no compose/buildx):

- **Before buildx:** `docker compose build` of a `--mount=type=cache` Dockerfile → `the --mount option requires BuildKit` (host's exact failure).
- **After buildx:** same build runs on BuildKit and completes — `BUILT_WITH_CACHE_MOUNT`, exit 0.

The full SSH/Ansible run against the Azure VM is only exercised on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
