### PR TITLE
Implement delete-account feature in the web client

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 ## Try it out!
 
-Kubernetes deployment: https://devsecops.stud.k8s.aet.cit.tum.de
+Rancher deployment (Kubernetes): https://devsecops.stud.k8s.aet.cit.tum.de
+
+Azure deployment (Docker Compose): http://135.116.196.120/
 
 API scheme (Swagger UI): https://devsecops.stud.k8s.aet.cit.tum.de/swagger-ui/index.html
 ## Local development

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Rancher deployment (Kubernetes): https://devsecops.stud.k8s.aet.cit.tum.de
 
 Azure deployment (Docker Compose): http://135.116.196.120/
 
+Coverage reports: https://aet-devops26.github.io/team-devsecops/
+
 API scheme (Swagger UI): https://devsecops.stud.k8s.aet.cit.tum.de/swagger-ui/index.html
 ## Local development
 

--- a/web-client/src/locales/de.ts
+++ b/web-client/src/locales/de.ts
@@ -54,6 +54,12 @@ export const DE = {
 			saving: 'Speichern…',
 			couldntReachServer: 'Server nicht erreichbar',
 			invalidRequest: 'Ungültige Anfrage',
+			deleteAccount: 'Konto löschen',
+			deleteAccountWarning:
+				'Dadurch werden dein Konto und alle gespeicherten Rezepte dauerhaft gelöscht. Dies kann nicht rückgängig gemacht werden.',
+			deleteAccountConfirm: 'Ja, mein Konto löschen',
+			deleteAccountCancel: 'Abbrechen',
+			deleting: 'Wird gelöscht…',
 		},
 		common: {
 			error: 'Fehler: {{message}}',

--- a/web-client/src/locales/en.ts
+++ b/web-client/src/locales/en.ts
@@ -54,6 +54,12 @@ export const EN = {
 			saving: 'Saving…',
 			couldntReachServer: "Couldn't reach the server",
 			invalidRequest: 'Invalid request',
+			deleteAccount: 'Delete account',
+			deleteAccountWarning:
+				'Permanently delete your account and all your saved recipes. This cannot be undone.',
+			deleteAccountConfirm: 'Yes, delete my account',
+			deleteAccountCancel: 'Cancel',
+			deleting: 'Deleting…',
 		},
 		common: {
 			error: 'Error: {{message}}',

--- a/web-client/src/locales/hu.ts
+++ b/web-client/src/locales/hu.ts
@@ -54,6 +54,12 @@ export const HU = {
 			saving: 'Mentés…',
 			couldntReachServer: 'A szerver nem érhető el',
 			invalidRequest: 'Hibás kérés',
+			deleteAccount: 'Fiók törlése',
+			deleteAccountWarning:
+				'Ez véglegesen törli a fiókodat és az összes mentett receptedet. A művelet nem vonható vissza.',
+			deleteAccountConfirm: 'Igen, töröld a fiókomat',
+			deleteAccountCancel: 'Mégse',
+			deleting: 'Törlés…',
 		},
 		common: {
 			error: 'Hiba: {{message}}',

--- a/web-client/src/locales/hu.ts
+++ b/web-client/src/locales/hu.ts
@@ -59,7 +59,7 @@ export const HU = {
 				'Ez véglegesen törli a fiókodat és az összes mentett receptedet. A művelet nem vonható vissza.',
 			deleteAccountConfirm: 'Igen, töröld a fiókomat',
 			deleteAccountCancel: 'Mégse',
-			deleting: 'Törlés…',
+			deleting: 'Törlés folyamatban…',
 		},
 		common: {
 			error: 'Hiba: {{message}}',

--- a/web-client/src/pages/ProfilePage.tsx
+++ b/web-client/src/pages/ProfilePage.tsx
@@ -65,6 +65,9 @@ export function ProfilePage() {
 	const [passwordStatus, setPasswordStatus] = useState<{ kind: 'error' | 'ok'; msg: string } | null>(null)
 	const [usernameSaving, setUsernameSaving] = useState(false)
 	const [passwordSaving, setPasswordSaving] = useState(false)
+	const [confirmingDelete, setConfirmingDelete] = useState(false)
+	const [deleting, setDeleting] = useState(false)
+	const [deleteStatus, setDeleteStatus] = useState<{ kind: 'error'; msg: string } | null>(null)
 
 	// fetch the currently stored user profile
 	useEffect(() => {
@@ -223,6 +226,20 @@ export function ProfilePage() {
 			setPasswordStatus({ kind: 'error', msg: e instanceof Error ? e.message : String(e) })
 		} finally {
 			setPasswordSaving(false)
+		}
+	}
+
+	async function handleDeleteAccount() {
+		setDeleting(true)
+		setDeleteStatus(null)
+		try {
+			const res = await apiFetch('/users/profile', { method: 'DELETE' })
+			if (!res.ok) throw new Error(await errorMessage(res))
+			signOut()
+			navigate('/login')
+		} catch (e) {
+			setDeleting(false)
+			setDeleteStatus({ kind: 'error', msg: e instanceof Error ? e.message : String(e) })
 		}
 	}
 
@@ -481,33 +498,51 @@ export function ProfilePage() {
 				</form>
 			</div>
 
-			{/* Delete Account (not yet supported by backend) */}
-			{/*<div className="w-full max-w-md rounded-lg border border-gray-200 bg-white p-6 shadow-sm self-center md:self-start">*/}
-			{/*  <form*/}
-			{/*    className="flex flex-col gap-4"*/}
-			{/*    onSubmit={(e) => e.preventDefault()}*/}
-			{/*  >*/}
-			{/*    <h2 className="text-lg font-bold">Delete account</h2>*/}
+			{/* Delete account */}
+			<div className="w-full max-w-md rounded-lg border border-gray-200 bg-white p-6 shadow-sm self-center md:self-start">
+				<div className="flex flex-col gap-4">
+					<h2 className="text-lg font-bold">{t('profile.deleteAccount')}</h2>
 
-			{/*    <label className="flex flex-col gap-1">*/}
-			{/*      <span className="font-medium">Password</span>*/}
-			{/*      <PasswordInput*/}
-			{/*        className="w-full border border-gray-300 rounded p-2"*/}
-			{/*        value={deletePassword}*/}
-			{/*        onChange={(e) => setDeletePassword(e.target.value)}*/}
-			{/*        autoComplete="current-password"*/}
-			{/*      />*/}
-			{/*    </label>*/}
+					{confirmingDelete ? (
+						<>
+							<p className="text-red-600">{t('profile.deleteAccountWarning')}</p>
+							<div className="flex items-center justify-center gap-4">
+								<button
+									type="button"
+									className="cursor-pointer text-gray-500 transition-transform duration-100 hover:scale-98 disabled:cursor-not-allowed disabled:opacity-50"
+									disabled={deleting}
+									onClick={() => setConfirmingDelete(false)}
+								>
+									{t('profile.deleteAccountCancel')}
+								</button>
+								<button
+									type="button"
+									className="flex items-center gap-1 cursor-pointer text-red-600 transition-transform duration-100 hover:scale-98 disabled:cursor-not-allowed disabled:opacity-50"
+									disabled={deleting}
+									onClick={handleDeleteAccount}
+								>
+									<TrashIcon className="h-5 w-5" />
+									{deleting ? t('profile.deleting') : t('profile.deleteAccountConfirm')}
+								</button>
+							</div>
+						</>
+					) : (
+						<button
+							type="button"
+							className="flex items-center gap-1 self-center text-red-600 cursor-pointer transition-transform duration-100 hover:scale-98"
+							onClick={() => {
+								setDeleteStatus(null)
+								setConfirmingDelete(true)
+							}}
+						>
+							<TrashIcon className="h-5 w-5" />
+							{t('profile.deleteAccount')}
+						</button>
+					)}
 
-			{/*    <button*/}
-			{/*      type="button"*/}
-			{/*      className="flex items-center gap-1 self-center text-red-600 cursor-pointer transition-transform duration-100 hover:scale-98"*/}
-			{/*    >*/}
-			{/*      <TrashIcon className="h-5 w-5" />*/}
-			{/*      Delete account*/}
-			{/*    </button>*/}
-			{/*  </form>*/}
-			{/*</div>*/}
+					{deleteStatus && <p className="text-red-600">{deleteStatus.msg}</p>}
+				</div>
+			</div>
 		</>
 	)
 }

--- a/web-client/tests/pages/ProfilePage.test.tsx
+++ b/web-client/tests/pages/ProfilePage.test.tsx
@@ -70,6 +70,20 @@ describe('ProfilePage', () => {
 		expect(await screen.findByText('Username already taken')).toBeInTheDocument()
 	})
 
+	it('deletes the account after confirmation and redirects to login', async () => {
+		defaultProfileFetch({username: 'alice'})
+		const user = userEvent.setup()
+		render()
+
+		await user.click(screen.getByRole('button', {name: 'Delete account'}))
+		await user.click(screen.getByRole('button', {name: 'Yes, delete my account'}))
+
+		const deleteCalls = fetchMock.mock.calls.filter(([, init]) => init?.method === 'DELETE')
+		expect(deleteCalls).toHaveLength(1)
+		expect(String(deleteCalls[0][0])).toContain('/users/profile')
+		expect(await screen.findByText('login page')).toBeInTheDocument()
+	})
+
 	describe('taste-preferences autosave', () => {
 		const status = () => document.querySelector('[data-status]:not([data-status="idle"])')
 			?.getAttribute('data-status') ?? 'idle'


### PR DESCRIPTION
## Summary

Wires up the previously stubbed **delete-account** card on the profile page to the new `DELETE /users/profile` backend endpoint (cascade-deletes the account and all saved recipes).

- Two-step confirmation guards the destructive action (no password field, since the endpoint authenticates via the bearer token alone).
- On success the user is signed out and redirected to `/login`.
- A genuine `SessionExpiredError` falls through to the route guard's redirect, same as the other profile handlers.
- Adds EN/DE/HU translations.
- Adds a happy-path test: confirm → single `DELETE /users/profile` → redirect to login.

Also updates the README with the Azure (Docker Compose) deployment URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)