### PR TITLE
Add per-PR frontend preview environments

### DIFF
--- a/.github/workflows/deploy-k8s-client-preview.yml
+++ b/.github/workflows/deploy-k8s-client-preview.yml
@@ -87,7 +87,10 @@ jobs:
           echo "${{ secrets.KUBE_CONFIG }}" | base64 -d > ~/.kube/config
           chmod 600 ~/.kube/config
       - name: Tear down preview
-        run: kubectl delete namespace "preview-pr-${{ github.event.pull_request.number }}" --ignore-not-found --wait=false
+        run: |
+          PR="${{ github.event.pull_request.number }}"
+          kubectl delete deployment,service,ingress -n app -l "preview-pr=$PR"
+          kubectl delete secret "preview-pr-$PR-tls" -n app --ignore-not-found
       - name: Update comment
         uses: marocchino/sticky-pull-request-comment@v2
         with:

--- a/.github/workflows/deploy-k8s-client-preview.yml
+++ b/.github/workflows/deploy-k8s-client-preview.yml
@@ -1,0 +1,96 @@
+name: PR Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+    paths:
+      - 'web-client/**'
+      - 'infra/k8s/preview/**'
+      - '.github/workflows/deploy-k8s-client-preview.yml'
+
+concurrency:
+  group: preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+  pull-requests: write
+
+env:
+  # gets prefixed with the PR number
+  PREVIEW_DOMAIN: devsecops.stud.k8s.aet.cit.tum.de
+
+jobs:
+  deploy:
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    environment: kubernetes
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Image prefix
+        run: echo "IMAGE_PREFIX=ghcr.io/$(echo "$GITHUB_REPOSITORY" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build web-client
+        uses: docker/build-push-action@v6
+        with:
+          context: web-client
+          push: true
+          tags: ${{ env.IMAGE_PREFIX }}/web-client:preview-pr-${{ github.event.pull_request.number }}
+
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v4
+
+      - name: Configure kubeconfig
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBE_CONFIG }}" | base64 -d > ~/.kube/config
+          chmod 600 ~/.kube/config
+
+      - name: Deploy preview
+        id: deploy
+        env:
+          WEB_CLIENT_IMAGE: ${{ env.IMAGE_PREFIX }}/web-client:preview-pr-${{ github.event.pull_request.number }}
+        run: |
+          url=$(infra/k8s/preview/deploy.sh "${{ github.event.pull_request.number }}")
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+
+      - name: Comment preview URL
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          number: ${{ github.event.pull_request.number }}
+          header: preview
+          message: 🚀 [Frontend preview ↗](${{ steps.deploy.outputs.url }}) &nbsp;·&nbsp; commit `${{ github.event.pull_request.head.sha }}`
+
+  teardown:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    environment: kubernetes
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v4
+      - name: Configure kubeconfig
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBE_CONFIG }}" | base64 -d > ~/.kube/config
+          chmod 600 ~/.kube/config
+      - name: Tear down preview
+        run: kubectl delete namespace "preview-pr-${{ github.event.pull_request.number }}" --ignore-not-found --wait=false
+      - name: Update comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          number: ${{ github.event.pull_request.number }}
+          header: preview
+          message: 🧹 The preview environment was removed because this PR was closed.

--- a/infra/k8s/preview/deploy.sh
+++ b/infra/k8s/preview/deploy.sh
@@ -13,6 +13,10 @@ HOST="pr-${PR}.${PREVIEW_DOMAIN:-devsecops.stud.k8s.aet.cit.tum.de}"
 export WEB_CLIENT_IMAGE="${WEB_CLIENT_IMAGE:?}"
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# Route command output to stderr (still shown in logs) so stdout carries only
+# the final URL line, which the caller captures. fd 3 is the real stdout.
+exec 3>&1 1>&2
+
 # web-client Deployment + Service, named/labelled per PR.
 envsubst '${PR} ${WEB_CLIENT_IMAGE}' < "$DIR/manifests.yaml" | kubectl apply -n "$NS" -f -
 
@@ -51,4 +55,4 @@ EOF
 kubectl rollout restart "deployment/web-client-pr-${PR}" -n "$NS"
 kubectl rollout status "deployment/web-client-pr-${PR}" -n "$NS" --timeout=180s
 
-echo "https://${HOST}/team-devsecops/"
+echo "https://${HOST}/team-devsecops/" >&3

--- a/infra/k8s/preview/deploy.sh
+++ b/infra/k8s/preview/deploy.sh
@@ -1,32 +1,30 @@
 #!/usr/bin/env bash
-# Deploy (or update) a per-PR frontend preview environment.
+# Deploy (or update) a per-PR frontend preview into the team's existing namespace.
 # Usage: deploy.sh <pr-number>
-# Env:   WEB_CLIENT_IMAGE (required) — web-client image ref to deploy
-#        PREVIEW_DOMAIN   (default devsecops.stud.k8s.aet.cit.tum.de)
+# Env:   WEB_CLIENT_IMAGE  (required) — web-client image ref to deploy
+#        PREVIEW_DOMAIN    (default devsecops.stud.k8s.aet.cit.tum.de)
+#        PREVIEW_NAMESPACE (default app)
 set -euo pipefail
 
 PR="${1:?pr number required}"
-NS="preview-pr-${PR}"
+export PR
+NS="${PREVIEW_NAMESPACE:-app}"
 HOST="pr-${PR}.${PREVIEW_DOMAIN:-devsecops.stud.k8s.aet.cit.tum.de}"
 export WEB_CLIENT_IMAGE="${WEB_CLIENT_IMAGE:?}"
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# create a new namespace
-kubectl create namespace "$NS" --dry-run=client -o yaml | kubectl apply -f -
-kubectl label namespace "$NS" \
-  app.kubernetes.io/part-of=pr-preview \
-  preview-pr="$PR" --overwrite
+# web-client Deployment + Service, named/labelled per PR.
+envsubst '${PR} ${WEB_CLIENT_IMAGE}' < "$DIR/manifests.yaml" | kubectl apply -n "$NS" -f -
 
-# deploy the manifests.yaml to our created namespace
-envsubst '${WEB_CLIENT_IMAGE}' < "$DIR/manifests.yaml" | kubectl apply -n "$NS" -f -
-
-# setup TLS and expose the deployment using an Ingress
-# (this is done inline to easily substitute $HOST)
+# Per-PR ingress (inline to substitute the host). Its own TLS secret avoids
+# collisions with production and other previews in this shared namespace.
 kubectl apply -n "$NS" -f - <<EOF
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: preview
+  name: preview-pr-${PR}
+  labels:
+    preview-pr: "${PR}"
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/proxy-read-timeout: "60"
@@ -35,7 +33,7 @@ spec:
   ingressClassName: nginx
   tls:
     - hosts: ["$HOST"]
-      secretName: preview-tls-cert
+      secretName: preview-pr-${PR}-tls
   rules:
     - host: "$HOST"
       http:
@@ -44,14 +42,13 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: web-client
+                name: web-client-pr-${PR}
                 port:
                   number: 8080
 EOF
 
-# restart to pull the image with the latest changes from the PR
-kubectl rollout restart deployment/web-client -n "$NS"
-# wait up to 180s for the pods to be up (otherwise fail)
-kubectl rollout status deployment/web-client -n "$NS" --timeout=180s
+# Stable per-PR tag → apply is a no-op on updates; restart to pull the new image.
+kubectl rollout restart "deployment/web-client-pr-${PR}" -n "$NS"
+kubectl rollout status "deployment/web-client-pr-${PR}" -n "$NS" --timeout=180s
 
 echo "https://${HOST}/team-devsecops/"

--- a/infra/k8s/preview/deploy.sh
+++ b/infra/k8s/preview/deploy.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Deploy (or update) a per-PR frontend preview environment.
+# Usage: deploy.sh <pr-number>
+# Env:   WEB_CLIENT_IMAGE (required) — web-client image ref to deploy
+#        PREVIEW_DOMAIN   (default devsecops.stud.k8s.aet.cit.tum.de)
+set -euo pipefail
+
+PR="${1:?pr number required}"
+NS="preview-pr-${PR}"
+HOST="pr-${PR}.${PREVIEW_DOMAIN:-devsecops.stud.k8s.aet.cit.tum.de}"
+export WEB_CLIENT_IMAGE="${WEB_CLIENT_IMAGE:?}"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# create a new namespace
+kubectl create namespace "$NS" --dry-run=client -o yaml | kubectl apply -f -
+kubectl label namespace "$NS" \
+  app.kubernetes.io/part-of=pr-preview \
+  preview-pr="$PR" --overwrite
+
+# deploy the manifests.yaml to our created namespace
+envsubst '${WEB_CLIENT_IMAGE}' < "$DIR/manifests.yaml" | kubectl apply -n "$NS" -f -
+
+# setup TLS and expose the deployment using an Ingress
+# (this is done inline to easily substitute $HOST)
+kubectl apply -n "$NS" -f - <<EOF
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: preview
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "60"
+    nginx.ingress.kubernetes.io/proxy-body-size: "10m"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts: ["$HOST"]
+      secretName: preview-tls-cert
+  rules:
+    - host: "$HOST"
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: web-client
+                port:
+                  number: 8080
+EOF
+
+# restart to pull the image with the latest changes from the PR
+kubectl rollout restart deployment/web-client -n "$NS"
+# wait up to 180s for the pods to be up (otherwise fail)
+kubectl rollout status deployment/web-client -n "$NS" --timeout=180s
+
+echo "https://${HOST}/team-devsecops/"

--- a/infra/k8s/preview/deploy.sh
+++ b/infra/k8s/preview/deploy.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Deploy (or update) a per-PR frontend preview into the team's existing namespace.
+# Deploy (or update) a per-PR frontend preview into the existing namespace.
 # Usage: deploy.sh <pr-number>
 # Env:   WEB_CLIENT_IMAGE  (required) — web-client image ref to deploy
 #        PREVIEW_DOMAIN    (default devsecops.stud.k8s.aet.cit.tum.de)
@@ -13,15 +13,14 @@ HOST="pr-${PR}.${PREVIEW_DOMAIN:-devsecops.stud.k8s.aet.cit.tum.de}"
 export WEB_CLIENT_IMAGE="${WEB_CLIENT_IMAGE:?}"
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# Route command output to stderr (still shown in logs) so stdout carries only
-# the final URL line, which the caller captures. fd 3 is the real stdout.
+# Route command output to stderr so stdout carries only the final URL line
 exec 3>&1 1>&2
 
-# web-client Deployment + Service, named/labelled per PR.
+# web-client Deployment + Service, named/labelled per PR
 envsubst '${PR} ${WEB_CLIENT_IMAGE}' < "$DIR/manifests.yaml" | kubectl apply -n "$NS" -f -
 
-# Per-PR ingress (inline to substitute the host). Its own TLS secret avoids
-# collisions with production and other previews in this shared namespace.
+# setup TLS and expose the deployment using an Ingress
+# (this is done inline to easily substitute $HOST)
 kubectl apply -n "$NS" -f - <<EOF
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -51,7 +50,7 @@ spec:
                   number: 8080
 EOF
 
-# Stable per-PR tag → apply is a no-op on updates; restart to pull the new image.
+# restart to pull the image with the latest changes from the PR
 kubectl rollout restart "deployment/web-client-pr-${PR}" -n "$NS"
 kubectl rollout status "deployment/web-client-pr-${PR}" -n "$NS" --timeout=180s
 

--- a/infra/k8s/preview/manifests.yaml
+++ b/infra/k8s/preview/manifests.yaml
@@ -1,19 +1,27 @@
 ---
-# Per-PR frontend preview
-# ${WEB_CLIENT_IMAGE} needs to be substituted by the caller
+# Per-PR frontend preview, deployed INTO the team's existing namespace (the AET
+# token is namespace-scoped and cannot create namespaces). Resources are named
+# and labelled per PR so they never collide with production or other previews.
+# The web-client's baked nginx proxies /api to the production spring-api Service,
+# which already lives in this namespace — no alias needed.
+#
+# Substituted by deploy.sh: ${PR}, ${WEB_CLIENT_IMAGE}.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: web-client
+  name: web-client-pr-${PR}
+  labels:
+    preview-pr: "${PR}"
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: web-client
+      app: web-client-pr-${PR}
   template:
     metadata:
       labels:
-        app: web-client
+        app: web-client-pr-${PR}
+        preview-pr: "${PR}"
     spec:
       containers:
         - name: web-client
@@ -41,25 +49,15 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 5
 ---
-# expose the pod at web-client:8080
 apiVersion: v1
 kind: Service
 metadata:
-  name: web-client
+  name: web-client-pr-${PR}
+  labels:
+    preview-pr: "${PR}"
 spec:
   selector:
-    app: web-client
+    app: web-client-pr-${PR}
   ports:
     - port: 8080
       targetPort: 8080
----
-# Make the prod backend available at spring-api:8080 for the frontend
-apiVersion: v1
-kind: Service
-metadata:
-  name: spring-api
-spec:
-  type: ExternalName
-  externalName: spring-api.app.svc.cluster.local
-  ports:
-    - port: 8080

--- a/infra/k8s/preview/manifests.yaml
+++ b/infra/k8s/preview/manifests.yaml
@@ -1,11 +1,6 @@
 ---
-# Per-PR frontend preview, deployed INTO the team's existing namespace (the AET
-# token is namespace-scoped and cannot create namespaces). Resources are named
-# and labelled per PR so they never collide with production or other previews.
-# The web-client's baked nginx proxies /api to the production spring-api Service,
-# which already lives in this namespace — no alias needed.
-#
-# Substituted by deploy.sh: ${PR}, ${WEB_CLIENT_IMAGE}.
+# Per-PR frontend preview
+# ${PR} and ${WEB_CLIENT_IMAGE} need to be substituted by the caller
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -49,6 +44,7 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 5
 ---
+# expose the pod at web-client:8080
 apiVersion: v1
 kind: Service
 metadata:

--- a/infra/k8s/preview/manifests.yaml
+++ b/infra/k8s/preview/manifests.yaml
@@ -1,0 +1,65 @@
+---
+# Per-PR frontend preview
+# ${WEB_CLIENT_IMAGE} needs to be substituted by the caller
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web-client
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: web-client
+  template:
+    metadata:
+      labels:
+        app: web-client
+    spec:
+      containers:
+        - name: web-client
+          image: ${WEB_CLIENT_IMAGE}
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8080
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+          livenessProbe:
+            httpGet:
+              path: /team-devsecops/
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /team-devsecops/
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 5
+---
+# expose the pod at web-client:8080
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-client
+spec:
+  selector:
+    app: web-client
+  ports:
+    - port: 8080
+      targetPort: 8080
+---
+# Make the prod backend available at spring-api:8080 for the frontend
+apiVersion: v1
+kind: Service
+metadata:
+  name: spring-api
+spec:
+  type: ExternalName
+  externalName: spring-api.app.svc.cluster.local
+  ports:
+    - port: 8080


### PR DESCRIPTION
Spins up a live preview of the **web-client** for every PR that touches the frontend, so reviewers get a clickable link.

- On open/sync: builds the PR's web-client, pushes it to GHCR, and deploys it into the `app` namespace as `web-client-pr-<N>`.
- Reuses the production `spring-api` (same namespace), so a preview is one ~50m/64Mi pod.
- Posts a sticky comment with the URL: `https://pr-<N>.devsecops.stud.k8s.aet.cit.tum.de/team-devsecops/`.
- Torn down (by `preview-pr` label) when the PR is closed.

Frontend-only by design — backend/DB changes aren't exercised (those are covered by per-service CI).