### PR TITLE
Setup logos support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,15 @@
 # Copy to .env and fill in.
 
+PROVIDER=google_genai
+
 # Google Gemini API key for the GenAI services — https://aistudio.google.com/apikey
-RECIPE_SERVICE_KEY=
-HELP_SERVICE_KEY=
+GEMINI_MODEL=gemini-3.1-flash-lite
+GEMINI_HELP_SERVICE_KEY=
+GEMINI_RECIPE_SERVICE_KEY=
+
+LOGOS_MODEL=openai/gpt-oss-120b
+LOGOS_BASE_URL=https://logos.aet.cit.tum.de/v1
+LOGOS_KEY=
 
 # Spring API (optional variables, if not defined in-memory db is automatically set up)
 DB_URL=jdbc:postgresql://host:5432/cooking

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # Copy to .env and fill in.
 
+# either `google_genai` or `openai` (Logos)
 PROVIDER=google_genai
 
 # Google Gemini API key for the GenAI services — https://aistudio.google.com/apikey

--- a/.github/workflows/build-help-service.yml
+++ b/.github/workflows/build-help-service.yml
@@ -55,7 +55,6 @@ jobs:
       - name: Run pytest
         env:
           INTERNAL_AUTH_SECRET: ${{ secrets.INTERNAL_AUTH_SECRET }}
-          SERVICE_API_KEY: ${{ secrets.SERVICE_API_KEY }}
         run: |
           pytest --junitxml=report.xml --cov=main --cov-report=html:htmlcov
 

--- a/.github/workflows/build-recipe-service.yml
+++ b/.github/workflows/build-recipe-service.yml
@@ -55,7 +55,6 @@ jobs:
       - name: Run pytest
         env:
           INTERNAL_AUTH_SECRET: ${{ secrets.INTERNAL_AUTH_SECRET }}
-          SERVICE_API_KEY: ${{ secrets.SERVICE_API_KEY }}
         run: |
           pytest --junitxml=report.xml --cov=main --cov-report=html:htmlcov
 

--- a/.github/workflows/deploy-ansible.yml
+++ b/.github/workflows/deploy-ansible.yml
@@ -45,8 +45,9 @@ jobs:
           ansible-playbook -i infra/inventory.ini ansible/site.yml \
           -u azureuser \
           -e "app_branch=${{ github.head_ref || github.ref_name }}" \
-          -e "help_service_key=${{ secrets.HELP_SERVICE_KEY }}" \
-          -e "recipe_service_key=${{ secrets.RECIPE_SERVICE_KEY }}" \
+          -e "gemini_model=${{ vars.GEMINI_MODEL }}" \
+          -e "gemini_help_service_key=${{ secrets.GEMINI_HELP_SERVICE_KEY }}" \
+          -e "gemini_recipe_service_key=${{ secrets.GEMINI_RECIPE_SERVICE_KEY }}" \
           -e "internal_auth_secret=${{ secrets.INTERNAL_AUTH_SECRET }}" \
           -e "db_user=${{ secrets.AZURE_DB_USER }}" \
           -e "db_password=${{ secrets.AZURE_DB_PASSWORD }}"

--- a/.github/workflows/deploy-k8s.yml
+++ b/.github/workflows/deploy-k8s.yml
@@ -73,12 +73,22 @@ jobs:
             --dry-run=client -o yaml | kubectl apply -f -
 
           kubectl create secret generic py-recipe-secret -n app \
-            --from-literal=SERVICE_API_KEY="${{ secrets.RECIPE_SERVICE_KEY }}" \
+            --from-literal=PROVIDER="${{ vars.PROVIDER }}" \
+            --from-literal=LOGOS_MODEL="${{ vars.LOGOS_MODEL }}" \
+            --from-literal=LOGOS_BASE_URL="${{ vars.LOGOS_BASE_URL }}" \
+            --from-literal=LOGOS_KEY="${{ secrets.LOGOS_KEY }}" \
+            --from-literal=GEMINI_MODEL="${{ vars.GEMINI_MODEL }}" \
+            --from-literal=GEMINI_RECIPE_SERVICE_KEY="${{ secrets.GEMINI_RECIPE_SERVICE_KEY }}" \
             --from-literal=INTERNAL_AUTH_SECRET="${{ secrets.INTERNAL_AUTH_SECRET }}" \
             --dry-run=client -o yaml | kubectl apply -f -
 
           kubectl create secret generic py-help-secret -n app \
-            --from-literal=SERVICE_API_KEY="${{ secrets.HELP_SERVICE_KEY }}" \
+            --from-literal=PROVIDER="${{ vars.PROVIDER }}" \
+            --from-literal=LOGOS_MODEL="${{ vars.LOGOS_MODEL }}" \
+            --from-literal=LOGOS_BASE_URL="${{ vars.LOGOS_BASE_URL }}" \
+            --from-literal=LOGOS_KEY="${{ secrets.LOGOS_KEY }}" \
+            --from-literal=GEMINI_MODEL="${{ vars.GEMINI_MODEL }}" \
+            --from-literal=GEMINI_HELP_SERVICE_KEY="${{ secrets.GEMINI_HELP_SERVICE_KEY }}" \
             --from-literal=INTERNAL_AUTH_SECRET="${{ secrets.INTERNAL_AUTH_SECRET }}" \
             --dry-run=client -o yaml | kubectl apply -f -
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,9 +3,8 @@ services:
     build: ./services/py-recipe-service
     ports:
       - "8090:8080"
-    environment:
-      SERVICE_API_KEY: ${RECIPE_SERVICE_KEY}
-      INTERNAL_AUTH_SECRET: ${INTERNAL_AUTH_SECRET}
+    env_file:
+      - ./.env
     develop:
       watch:
         - action: sync+restart
@@ -23,9 +22,8 @@ services:
     build: ./services/py-help-service
     ports:
       - "8091:8080"
-    environment:
-      SERVICE_API_KEY: ${HELP_SERVICE_KEY}
-      INTERNAL_AUTH_SECRET: ${INTERNAL_AUTH_SECRET}
+    env_file:
+      - ./.env
     develop:
       watch:
         - action: sync+restart
@@ -46,7 +44,6 @@ services:
     environment:
       AI_RECIPE_SERVICE_URL: http://py-recipe-service:8080
       AI_HELP_SERVICE_URL: http://py-help-service:8080
-      INTERNAL_AUTH_SECRET: ${INTERNAL_AUTH_SECRET}
     env_file:
       - ./.env
     depends_on:

--- a/infra/.env.j2
+++ b/infra/.env.j2
@@ -1,6 +1,11 @@
 # .env.j2
-HELP_SERVICE_KEY={{ help_service_key }}
-RECIPE_SERVICE_KEY={{ recipe_service_key }}
+
+PROVIDER=google_genai
+
+GEMINI_MODEL={{ gemini_model }}
+GEMINI_HELP_SERVICE_KEY={{ gemini_help_service_key }}
+GEMINI_RECIPE_SERVICE_KEY={{ gemini_recipe_service_key }}
+
 INTERNAL_AUTH_SECRET={{ internal_auth_secret }}
 
 DB_USER={{ db_user }}

--- a/infra/.env.j2
+++ b/infra/.env.j2
@@ -1,5 +1,6 @@
 # .env.j2
 
+# only google_genai is supported (no Logos access on Azure)
 PROVIDER=google_genai
 
 GEMINI_MODEL={{ gemini_model }}

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -23,9 +23,6 @@ services:
       - "8080"
     networks:
       - backend
-    environment:
-      SERVICE_API_KEY: ${RECIPE_SERVICE_KEY}
-      INTERNAL_AUTH_SECRET: ${INTERNAL_AUTH_SECRET}
 
   py-help-service:
     build: ../services/py-help-service
@@ -34,9 +31,6 @@ services:
       - "8080"
     networks:
       - backend
-    environment:
-      SERVICE_API_KEY: ${HELP_SERVICE_KEY}
-      INTERNAL_AUTH_SECRET: ${INTERNAL_AUTH_SECRET}
 
   postgres-db:
     image: postgres:15-alpine

--- a/services/py-help-service/main.py
+++ b/services/py-help-service/main.py
@@ -107,7 +107,7 @@ def get_llm():
 			raise RuntimeError("CRITICAL: LOGOS_KEY is missing!")
 
 		kwargs["base_url"] = os.getenv(
-			"LOGOS_BASE_URL", "https://logos.aet.cit.tum.de/v1]"
+			"LOGOS_BASE_URL", "https://logos.aet.cit.tum.de/v1"
 		)
 		kwargs["api_key"] = logos_key
 		model_name = os.getenv("LOGOS_MODEL", "openai/gpt-oss-120b")

--- a/services/py-help-service/main.py
+++ b/services/py-help-service/main.py
@@ -7,7 +7,7 @@ from typing import Any
 from fastapi import Depends, FastAPI, HTTPException, Header, Request
 from dotenv import load_dotenv
 from fastapi.responses import JSONResponse
-from langchain_google_genai import ChatGoogleGenerativeAI
+from langchain.chat_models import init_chat_model
 from langchain_core.messages import HumanMessage, SystemMessage
 
 from client.cooking_assistant_gen_ai_services_api_internal_client.models.help_request_forwarded import HelpRequestForwarded
@@ -74,13 +74,41 @@ async def verify_internal_hmac(
 	if not hmac.compare_digest(expected_signature, x_internal_signature):
 		raise HTTPException(status_code=403, detail={"message": "Forbidden: HMAC signature validation mismatch."})
 
-
 def get_llm():
-	return ChatGoogleGenerativeAI(
-		model="gemini-3.1-flash-lite",
-		google_api_key=os.getenv("SERVICE_API_KEY"),
-		timeout=30,
-	)
+    """
+    Dynamically builds the correct LLM structure using environment variables.
+    """
+    # Fix 1: Normalize provider string variants safely
+    provider = os.getenv("PROVIDER", "google_genai")
+    
+    kwargs = {"timeout": 30}
+
+    if provider == "openai":
+        logos_key = os.getenv("LOGOS_KEY")
+        if not logos_key:
+            raise RuntimeError("CRITICAL: LOGOS_KEY is missing!")
+            
+        kwargs["base_url"] = os.getenv("LOGOS_BASE_URL", "[https://logos.aet.cit.tum.de/v1](https://logos.aet.cit.tum.de/v1)")
+        kwargs["api_key"] = logos_key
+        model_name = os.getenv("LOGOS_MODEL", "openai/gpt-oss-120b")
+        
+    else:
+        gemini_key = os.getenv("GEMINI_RECIPE_SERVICE_KEY")
+        if not gemini_key:
+            raise RuntimeError("CRITICAL: GEMINI_RECIPE_SERVICE_KEY is missing!")
+            
+        kwargs["google_api_key"] = gemini_key
+        kwargs["response_format"] = {"type": "application/json"}
+        model_name = os.getenv("GEMINI_MODEL", "gemini-3.1-flash-lite")
+
+    try:
+        return init_chat_model(
+            model=model_name,
+            model_provider=provider,
+            **kwargs
+        )
+    except Exception as e:
+        raise RuntimeError(f"Failed to boot LLM provider '{provider}': {e}")
 
 
 @app.get("/health")
@@ -89,7 +117,7 @@ def health_check():
 
 
 @app.post("/ai/help", dependencies=[Depends(verify_internal_hmac)])
-async def generate_help(request_data: dict[str, Any], llm: ChatGoogleGenerativeAI = Depends(get_llm)):
+async def generate_help(request_data: dict[str, Any], llm = Depends(get_llm)):
 	try:
 		request = HelpRequestForwarded.from_dict(request_data)
 	except Exception as e:

--- a/services/py-help-service/main.py
+++ b/services/py-help-service/main.py
@@ -10,32 +10,40 @@ from fastapi.responses import JSONResponse
 from langchain.chat_models import init_chat_model
 from langchain_core.messages import HumanMessage, SystemMessage
 
-from client.cooking_assistant_gen_ai_services_api_internal_client.models.help_request_forwarded import HelpRequestForwarded
-from client.cooking_assistant_gen_ai_services_api_internal_client.models.help_response import HelpResponse
+from client.cooking_assistant_gen_ai_services_api_internal_client.models.help_request_forwarded import (
+	HelpRequestForwarded,
+)
+from client.cooking_assistant_gen_ai_services_api_internal_client.models.help_response import (
+	HelpResponse,
+)
 
 # Load variables from .env for local testing
 load_dotenv()
 
 app = FastAPI(title="Cooking Assistant GenAI Service")
 
+
 @app.exception_handler(HTTPException)
 async def http_exception_handler(request: Request, exc: HTTPException):
 	body = exc.detail if isinstance(exc.detail, dict) else {"message": exc.detail}
 	return JSONResponse(status_code=exc.status_code, content=body, headers=exc.headers)
 
+
 LANGUAGE_NAMES = {"EN": "English", "DE": "German", "HU": "Hungarian"}
 
 SECRET_KEY_STR = os.getenv("INTERNAL_AUTH_SECRET")
 if not SECRET_KEY_STR:
-	raise RuntimeError("CRITICAL: INTERNAL_AUTH_SECRET environment variable is missing!")
+	raise RuntimeError(
+		"CRITICAL: INTERNAL_AUTH_SECRET environment variable is missing!"
+	)
 
-SECRET_KEY_BYTES = SECRET_KEY_STR.encode('utf-8')
+SECRET_KEY_BYTES = SECRET_KEY_STR.encode("utf-8")
 
 
 async def verify_internal_hmac(
 	request: Request,
 	x_internal_timestamp: str = Header(None),
-	x_internal_signature: str = Header(None)
+	x_internal_signature: str = Header(None),
 ):
 	"""
 	Validates that the incoming request contains an authentic HMAC signature bound to the timestamp and the request payload.
@@ -44,19 +52,26 @@ async def verify_internal_hmac(
 	if not x_internal_timestamp or not x_internal_signature:
 		raise HTTPException(
 			status_code=401,
-			detail={"message": "Unauthorized: Missing security authentication headers."}
+			detail={
+				"message": "Unauthorized: Missing security authentication headers."
+			},
 		)
 
 	# 1. Parse incoming timestamp string context securely
 	try:
 		request_time = int(x_internal_timestamp)
 	except ValueError:
-		raise HTTPException(status_code=400, detail={"message": "Invalid timestamp metadata formatting."})
+		raise HTTPException(
+			status_code=400,
+			detail={"message": "Invalid timestamp metadata formatting."},
+		)
 
 	# 2. Reject requests with more than 5 minutes of clock drift
 	current_time = int(time.time())
 	if abs(current_time - request_time) > 300:
-		raise HTTPException(status_code=401, detail={"message": "Request token signature expired."})
+		raise HTTPException(
+			status_code=401, detail={"message": "Request token signature expired."}
+		)
 
 	# 3. Read the raw body bytes directly from the stream
 	body_bytes = await request.body()
@@ -64,51 +79,52 @@ async def verify_internal_hmac(
 	# 4. Recalculate signature locally by hashing both pieces together
 	# Using a separator byte like b'.' prevents boundary shifting bugs
 	hmac_context = hmac.new(SECRET_KEY_BYTES, digestmod=hashlib.sha256)
-	hmac_context.update(x_internal_timestamp.encode('utf-8'))
-	hmac_context.update(b'.')
+	hmac_context.update(x_internal_timestamp.encode("utf-8"))
+	hmac_context.update(b".")
 	hmac_context.update(body_bytes)
 
 	expected_signature = hmac_context.hexdigest()
 
 	# 5. Use constant-time comparison to completely prevent timing attacks
 	if not hmac.compare_digest(expected_signature, x_internal_signature):
-		raise HTTPException(status_code=403, detail={"message": "Forbidden: HMAC signature validation mismatch."})
+		raise HTTPException(
+			status_code=403,
+			detail={"message": "Forbidden: HMAC signature validation mismatch."},
+		)
+
 
 def get_llm():
-    """
-    Dynamically builds the correct LLM structure using environment variables.
-    """
-    # Fix 1: Normalize provider string variants safely
-    provider = os.getenv("PROVIDER", "google_genai")
-    
-    kwargs = {"timeout": 30}
+	"""
+	Dynamically builds the correct LLM structure using environment variables.
+	"""
+	provider = os.getenv("PROVIDER", "google_genai")
 
-    if provider == "openai":
-        logos_key = os.getenv("LOGOS_KEY")
-        if not logos_key:
-            raise RuntimeError("CRITICAL: LOGOS_KEY is missing!")
-            
-        kwargs["base_url"] = os.getenv("LOGOS_BASE_URL", "[https://logos.aet.cit.tum.de/v1](https://logos.aet.cit.tum.de/v1)")
-        kwargs["api_key"] = logos_key
-        model_name = os.getenv("LOGOS_MODEL", "openai/gpt-oss-120b")
-        
-    else:
-        gemini_key = os.getenv("GEMINI_RECIPE_SERVICE_KEY")
-        if not gemini_key:
-            raise RuntimeError("CRITICAL: GEMINI_RECIPE_SERVICE_KEY is missing!")
-            
-        kwargs["google_api_key"] = gemini_key
-        kwargs["response_format"] = {"type": "application/json"}
-        model_name = os.getenv("GEMINI_MODEL", "gemini-3.1-flash-lite")
+	kwargs = {"timeout": 60}
 
-    try:
-        return init_chat_model(
-            model=model_name,
-            model_provider=provider,
-            **kwargs
-        )
-    except Exception as e:
-        raise RuntimeError(f"Failed to boot LLM provider '{provider}': {e}")
+	if provider == "openai":
+		logos_key = os.getenv("LOGOS_KEY")
+		if not logos_key:
+			raise RuntimeError("CRITICAL: LOGOS_KEY is missing!")
+
+		kwargs["base_url"] = os.getenv(
+			"LOGOS_BASE_URL", "https://logos.aet.cit.tum.de/v1]"
+		)
+		kwargs["api_key"] = logos_key
+		model_name = os.getenv("LOGOS_MODEL", "openai/gpt-oss-120b")
+
+	else:
+		gemini_key = os.getenv("GEMINI_HELP_SERVICE_KEY")
+		if not gemini_key:
+			raise RuntimeError("CRITICAL: GEMINI_HELP_SERVICE_KEY is missing!")
+
+		kwargs["google_api_key"] = gemini_key
+		kwargs["response_format"] = {"type": "application/json"}
+		model_name = os.getenv("GEMINI_MODEL", "gemini-3.1-flash-lite")
+
+	try:
+		return init_chat_model(model=model_name, model_provider=provider, **kwargs)
+	except Exception as e:
+		raise RuntimeError(f"Failed to boot LLM provider '{provider}': {e}")
 
 
 @app.get("/health")
@@ -117,11 +133,13 @@ def health_check():
 
 
 @app.post("/ai/help", dependencies=[Depends(verify_internal_hmac)])
-async def generate_help(request_data: dict[str, Any], llm = Depends(get_llm)):
+async def generate_help(request_data: dict[str, Any], llm=Depends(get_llm)):
 	try:
 		request = HelpRequestForwarded.from_dict(request_data)
 	except Exception as e:
-		raise HTTPException(status_code=400, detail={"message": f"Invalid request format: {str(e)}"})
+		raise HTTPException(
+			status_code=400, detail={"message": f"Invalid request format: {str(e)}"}
+		)
 
 	try:
 		context = ["You are a professional culinary assistant."]
@@ -130,12 +148,16 @@ async def generate_help(request_data: dict[str, Any], llm = Depends(get_llm)):
 		if request.profile and request.profile.preferences:
 			prefs = request.profile.preferences
 
-			language = LANGUAGE_NAMES.get(getattr(prefs.language, "value", None) or "EN", "English")
+			language = LANGUAGE_NAMES.get(
+				getattr(prefs.language, "value", None) or "EN", "English"
+			)
 			context.append(f"You serve a user speaking {language}.")
 
 			diet = prefs.diet or []
 			if diet:
-				context.append(f"The user specifies the following diet: {', '.join(diet)}.")
+				context.append(
+					f"The user specifies the following diet: {', '.join(diet)}."
+				)
 
 			about_me = prefs.about_me or []
 			if about_me:
@@ -143,21 +165,29 @@ async def generate_help(request_data: dict[str, Any], llm = Depends(get_llm)):
 
 			allergies = prefs.allergies or []
 			if allergies:
-				context.append(f"Important: The user is allergic to: {', '.join(allergies)}.")
+				context.append(
+					f"Important: The user is allergic to: {', '.join(allergies)}."
+				)
 
 		if request.recipe:
-			context.append(f"The user is currently looking at a recipe for '{request.recipe.title}'.")
+			context.append(
+				f"The user is currently looking at a recipe for '{request.recipe.title}'."
+			)
 
 		# Combine into LLM prompt
 		system_prompt = SystemMessage(content=" ".join(context))
 		user_prompt = HumanMessage(content=request.prompt)
 
-		result = await asyncio.wait_for(llm.ainvoke([system_prompt, user_prompt]), timeout=60)
+		result = await asyncio.wait_for(
+			llm.ainvoke([system_prompt, user_prompt]), timeout=60
+		)
 
 		help_response = HelpResponse(response=result.content)
 		return help_response.to_dict()
 
 	except asyncio.TimeoutError:
-		raise HTTPException(status_code=504, detail={"message": "LLM connection timed out."})
+		raise HTTPException(
+			status_code=504, detail={"message": "LLM connection timed out."}
+		)
 	except Exception as e:
 		raise HTTPException(status_code=500, detail={"message": str(e)})

--- a/services/py-help-service/requirements.txt
+++ b/services/py-help-service/requirements.txt
@@ -1,10 +1,10 @@
 fastapi==0.111.0
 uvicorn==0.30.1
-langchain
-langchain-openai
+langchain==1.3.11
+langchain-openai==1.3.3
 langchain-google-genai==2.1.12
-langchain-core==1.4.0
+langchain-core==1.4.7
 pydantic==2.7.4
 python-dotenv==1.0.1
-attrs
-python-dateutil
+attrs==23.2.0
+python-dateutil==2.9.0.post0

--- a/services/py-help-service/requirements.txt
+++ b/services/py-help-service/requirements.txt
@@ -1,5 +1,7 @@
 fastapi==0.111.0
 uvicorn==0.30.1
+langchain
+langchain-openai
 langchain-google-genai==2.1.12
 langchain-core==1.4.0
 pydantic==2.7.4

--- a/services/py-recipe-service/main.py
+++ b/services/py-recipe-service/main.py
@@ -9,7 +9,7 @@ from typing import Any
 from fastapi import Depends, FastAPI, HTTPException, Header, Request
 from dotenv import load_dotenv
 from fastapi.responses import JSONResponse
-from langchain_google_genai import ChatGoogleGenerativeAI
+from langchain.chat_models import init_chat_model
 from langchain_core.messages import HumanMessage, SystemMessage
 
 from client.cooking_assistant_gen_ai_services_api_internal_client.models.recipe_request_forwarded import RecipeRequestForwarded
@@ -76,18 +76,49 @@ async def verify_internal_hmac(
 
 
 def get_llm():
-    return ChatGoogleGenerativeAI(
-        model="gemini-3.1-flash-lite",
-        google_api_key=os.getenv("SERVICE_API_KEY"),
-        timeout=30,
-    )
+    """
+    Dynamically builds the correct LLM structure using environment variables.
+    """
+    # Fix 1: Normalize provider string variants safely
+    provider = os.getenv("PROVIDER", "google_genai")
+    
+    kwargs = {"timeout": 30}
+
+    if provider == "openai":
+        logos_key = os.getenv("LOGOS_KEY")
+        if not logos_key:
+            raise RuntimeError("CRITICAL: LOGOS_KEY is missing!")
+            
+        kwargs["base_url"] = os.getenv("LOGOS_BASE_URL", "[https://logos.aet.cit.tum.de/v1](https://logos.aet.cit.tum.de/v1)")
+        kwargs["api_key"] = logos_key
+        kwargs["response_format"] = {"type": "json_object"}
+        model_name = os.getenv("LOGOS_MODEL", "openai/gpt-oss-120b")
+        
+    else:
+        gemini_key = os.getenv("GEMINI_RECIPE_SERVICE_KEY")
+        if not gemini_key:
+            raise RuntimeError("CRITICAL: GEMINI_RECIPE_SERVICE_KEY is missing!")
+            
+        kwargs["google_api_key"] = gemini_key
+        kwargs["response_format"] = {"type": "application/json"}
+        model_name = os.getenv("GEMINI_MODEL", "gemini-3.1-flash-lite")
+
+    try:
+        return init_chat_model(
+            model=model_name,
+            model_provider=provider,
+            max_retries=0,
+            **kwargs
+        )
+    except Exception as e:
+        raise RuntimeError(f"Failed to boot LLM provider '{provider}': {e}")
 
 @app.get("/health")
 def health_check():
     return {"status": "healthy"}
 
 @app.post("/ai/recipes", dependencies=[Depends(verify_internal_hmac)])
-async def generate_recipes(request_data: dict[str, Any], llm: ChatGoogleGenerativeAI = Depends(get_llm)):
+async def generate_recipes(request_data: dict[str, Any], llm = Depends(get_llm)):
 
     try:
         request = RecipeRequestForwarded.from_dict(request_data)

--- a/services/py-recipe-service/main.py
+++ b/services/py-recipe-service/main.py
@@ -12,179 +12,201 @@ from fastapi.responses import JSONResponse
 from langchain.chat_models import init_chat_model
 from langchain_core.messages import HumanMessage, SystemMessage
 
-from client.cooking_assistant_gen_ai_services_api_internal_client.models.recipe_request_forwarded import RecipeRequestForwarded
+from client.cooking_assistant_gen_ai_services_api_internal_client.models.recipe_request_forwarded import (
+	RecipeRequestForwarded,
+)
 
 # Load variables from .env for local testing
 load_dotenv()
 
 app = FastAPI(title="Cooking Assistant GenAI Service")
 
+
 @app.exception_handler(HTTPException)
 async def http_exception_handler(request: Request, exc: HTTPException):
 	body = exc.detail if isinstance(exc.detail, dict) else {"message": exc.detail}
 	return JSONResponse(status_code=exc.status_code, content=body, headers=exc.headers)
 
+
 LANGUAGE_NAMES = {"EN": "English", "DE": "German", "HU": "Hungarian"}
 
 SECRET_KEY_STR = os.getenv("INTERNAL_AUTH_SECRET")
 if not SECRET_KEY_STR:
-    raise RuntimeError("CRITICAL: INTERNAL_AUTH_SECRET environment variable is missing!")
+	raise RuntimeError(
+		"CRITICAL: INTERNAL_AUTH_SECRET environment variable is missing!"
+	)
 
-SECRET_KEY_BYTES = SECRET_KEY_STR.encode('utf-8')
+SECRET_KEY_BYTES = SECRET_KEY_STR.encode("utf-8")
+
 
 async def verify_internal_hmac(
-    request: Request,
-    x_internal_timestamp: str = Header(None),
-    x_internal_signature: str = Header(None)
+	request: Request,
+	x_internal_timestamp: str = Header(None),
+	x_internal_signature: str = Header(None),
 ):
-    """
-    Validates that the incoming request contains an authentic HMAC signature bound to the timestamp and the request payload.
-    Caution: Redundant versions of this method in py-help-service and py-recipe service.
-    """
-    if not x_internal_timestamp or not x_internal_signature:
-        raise HTTPException(
-            status_code=401,
-            detail={"message": "Unauthorized: Missing security authentication headers."}
-        )
+	"""
+	Validates that the incoming request contains an authentic HMAC signature bound to the timestamp and the request payload.
+	Caution: Redundant versions of this method in py-help-service and py-recipe service.
+	"""
+	if not x_internal_timestamp or not x_internal_signature:
+		raise HTTPException(
+			status_code=401,
+			detail={
+				"message": "Unauthorized: Missing security authentication headers."
+			},
+		)
 
-    # 1. Parse incoming timestamp string context securely
-    try:
-        request_time = int(x_internal_timestamp)
-    except ValueError:
-        raise HTTPException(status_code=400, detail={"message": "Invalid timestamp metadata formatting."})
+	# 1. Parse incoming timestamp string context securely
+	try:
+		request_time = int(x_internal_timestamp)
+	except ValueError:
+		raise HTTPException(
+			status_code=400,
+			detail={"message": "Invalid timestamp metadata formatting."},
+		)
 
-    # 2. Reject requests with more than 5 minutes of clock drift
-    current_time = int(time.time())
-    if abs(current_time - request_time) > 300:
-        raise HTTPException(status_code=401, detail={"message": "Request token signature expired."})
+	# 2. Reject requests with more than 5 minutes of clock drift
+	current_time = int(time.time())
+	if abs(current_time - request_time) > 300:
+		raise HTTPException(
+			status_code=401, detail={"message": "Request token signature expired."}
+		)
 
-    # 3. Read the raw body bytes directly from the stream
-    body_bytes = await request.body()
+	# 3. Read the raw body bytes directly from the stream
+	body_bytes = await request.body()
 
-    # 4. Recalculate signature locally by hashing both pieces together
-    # Using a separator byte like b'.' prevents boundary shifting bugs
-    hmac_context = hmac.new(SECRET_KEY_BYTES, digestmod=hashlib.sha256)
-    hmac_context.update(x_internal_timestamp.encode('utf-8'))
-    hmac_context.update(b'.')
-    hmac_context.update(body_bytes)
+	# 4. Recalculate signature locally by hashing both pieces together
+	# Using a separator byte like b'.' prevents boundary shifting bugs
+	hmac_context = hmac.new(SECRET_KEY_BYTES, digestmod=hashlib.sha256)
+	hmac_context.update(x_internal_timestamp.encode("utf-8"))
+	hmac_context.update(b".")
+	hmac_context.update(body_bytes)
 
-    expected_signature = hmac_context.hexdigest()
+	expected_signature = hmac_context.hexdigest()
 
-    # 5. Use constant-time comparison to completely prevent timing attacks
-    if not hmac.compare_digest(expected_signature, x_internal_signature):
-        raise HTTPException(status_code=403, detail={"message": "Forbidden: HMAC signature validation mismatch."})
+	# 5. Use constant-time comparison to completely prevent timing attacks
+	if not hmac.compare_digest(expected_signature, x_internal_signature):
+		raise HTTPException(
+			status_code=403,
+			detail={"message": "Forbidden: HMAC signature validation mismatch."},
+		)
 
 
 def get_llm():
-    """
-    Dynamically builds the correct LLM structure using environment variables.
-    """
-    # Fix 1: Normalize provider string variants safely
-    provider = os.getenv("PROVIDER", "google_genai")
-    
-    kwargs = {"timeout": 30}
+	"""
+	Dynamically builds the correct LLM structure using environment variables.
+	"""
+	provider = os.getenv("PROVIDER", "google_genai")
 
-    if provider == "openai":
-        logos_key = os.getenv("LOGOS_KEY")
-        if not logos_key:
-            raise RuntimeError("CRITICAL: LOGOS_KEY is missing!")
-            
-        kwargs["base_url"] = os.getenv("LOGOS_BASE_URL", "[https://logos.aet.cit.tum.de/v1](https://logos.aet.cit.tum.de/v1)")
-        kwargs["api_key"] = logos_key
-        kwargs["response_format"] = {"type": "json_object"}
-        model_name = os.getenv("LOGOS_MODEL", "openai/gpt-oss-120b")
-        
-    else:
-        gemini_key = os.getenv("GEMINI_RECIPE_SERVICE_KEY")
-        if not gemini_key:
-            raise RuntimeError("CRITICAL: GEMINI_RECIPE_SERVICE_KEY is missing!")
-            
-        kwargs["google_api_key"] = gemini_key
-        kwargs["response_format"] = {"type": "application/json"}
-        model_name = os.getenv("GEMINI_MODEL", "gemini-3.1-flash-lite")
+	kwargs = {"timeout": 60}
 
-    try:
-        return init_chat_model(
-            model=model_name,
-            model_provider=provider,
-            max_retries=0,
-            **kwargs
-        )
-    except Exception as e:
-        raise RuntimeError(f"Failed to boot LLM provider '{provider}': {e}")
+	if provider == "openai":
+		logos_key = os.getenv("LOGOS_KEY")
+		if not logos_key:
+			raise RuntimeError("CRITICAL: LOGOS_KEY is missing!")
+
+		kwargs["base_url"] = os.getenv(
+			"LOGOS_BASE_URL", "https://logos.aet.cit.tum.de/v1"
+		)
+		kwargs["api_key"] = logos_key
+		kwargs["response_format"] = {"type": "json_object"}
+		model_name = os.getenv("LOGOS_MODEL", "openai/gpt-oss-120b")
+
+	else:
+		gemini_key = os.getenv("GEMINI_RECIPE_SERVICE_KEY")
+		if not gemini_key:
+			raise RuntimeError("CRITICAL: GEMINI_RECIPE_SERVICE_KEY is missing!")
+
+		kwargs["google_api_key"] = gemini_key
+		kwargs["response_format"] = {"type": "application/json"}
+		model_name = os.getenv("GEMINI_MODEL", "gemini-3.1-flash-lite")
+
+	try:
+		return init_chat_model(model=model_name, model_provider=provider, **kwargs)
+	except Exception as e:
+		raise RuntimeError(f"Failed to boot LLM provider '{provider}': {e}")
+
 
 @app.get("/health")
 def health_check():
-    return {"status": "healthy"}
+	return {"status": "healthy"}
+
 
 @app.post("/ai/recipes", dependencies=[Depends(verify_internal_hmac)])
-async def generate_recipes(request_data: dict[str, Any], llm = Depends(get_llm)):
+async def generate_recipes(request_data: dict[str, Any], llm=Depends(get_llm)):
 
-    try:
-        request = RecipeRequestForwarded.from_dict(request_data)
-    except Exception as e:
-        raise HTTPException(status_code=400, detail={"message": f"Invalid request format: {str(e)}"})
+	try:
+		request = RecipeRequestForwarded.from_dict(request_data)
+	except Exception as e:
+		raise HTTPException(
+			status_code=400, detail={"message": f"Invalid request format: {str(e)}"}
+		)
 
-    if not request.profile or not request.profile.preferences:
-        raise HTTPException(status_code=400, detail={"message": "Missing required profile preferences."})
+	if not request.profile or not request.profile.preferences:
+		raise HTTPException(
+			status_code=400, detail={"message": "Missing required profile preferences."}
+		)
 
-    try:
+	try:
+		# 1. Extract Profile Context
+		prefs = request.profile.preferences
+		diet = ", ".join(prefs.diet) if prefs.diet else "None"
+		allergies = ", ".join(prefs.allergies) if prefs.allergies else "None"
+		about = ", ".join(prefs.about_me) if prefs.about_me else "None"
+		language = LANGUAGE_NAMES.get(
+			getattr(prefs.language, "value", None) or "EN", "English"
+		)
 
-        # 1. Extract Profile Context
-        prefs = request.profile.preferences
-        diet = ", ".join(prefs.diet) if prefs.diet else "None"
-        allergies = ", ".join(prefs.allergies) if prefs.allergies else "None"
-        about = ", ".join(prefs.about_me) if prefs.about_me else "None"
-        language = LANGUAGE_NAMES.get(getattr(prefs.language, "value", None) or "EN", "English")
-
-        # 2. Build the System Prompt with strict JSON requirements
-        system_prompt = (
-            "You are a professional chef. Create a collection of distinct high-quality recipes.\n"
-            f"Constraint - Diet: {diet}\n"
-            f"Constraint - Allergies: {allergies} (DO NOT USE THESE)\n"
-            f"User Context: {about}\n\n"
-            "Respond ONLY with a JSON object matching this schema:\n"
-            "{\n"
-            "  \"recipes\": [\n"
-            "    {\n"
-            "      \"title\": \"string\",\n"
-            "      \"ingredients\": [{\"quantity\": number, \"unit\": \"string\", \"name\": \"string\"}],\n"
-            "      \"instructions\": [\"string\"],\n"
-            "      \"portions\": number,\n"
-            "      \"nutrients\": {\"calories\": int, \"protein\": int, \"fat\": int, \"carbs\": int}\n"
-            "    }\n"
-            "  ]\n"
-            "}"
+		# 2. Build the System Prompt with strict JSON requirements
+		system_prompt = (
+			"You are a professional chef. Create a collection of distinct high-quality recipes.\n"
+			f"Constraint - Diet: {diet}\n"
+			f"Constraint - Allergies: {allergies} (DO NOT USE THESE)\n"
+			f"User Context: {about}\n\n"
+			"Respond ONLY with a JSON object matching this schema:\n"
+			"{\n"
+			'  "recipes": [\n'
+			"    {\n"
+			'      "title": "string",\n'
+			'      "ingredients": [{"quantity": number, "unit": "string", "name": "string"}],\n'
+			'      "instructions": ["string"],\n'
+			'      "portions": number,\n'
+			'      "nutrients": {"calories": int, "protein": int, "fat": int, "carbs": int}\n'
+			"    }\n"
+			"  ]\n"
+			"}"
 			f"Write all recipe content (title, ingredients, units and instructions) in {language}. "
 			f"Keep the JSON keys in English as specified."
-        )
+		)
 
-        # 3. Invoke LLM
-        messages = [
-            SystemMessage(content=system_prompt),
-            HumanMessage(content=f"Generate 3 distinct recipes for: {request.prompt}")
-        ]
+		# 3. Invoke LLM
+		messages = [
+			SystemMessage(content=system_prompt),
+			HumanMessage(content=f"Generate 3 distinct recipes for: {request.prompt}"),
+		]
 
-        response = await asyncio.wait_for(llm.ainvoke(messages), timeout=60)
+		response = await asyncio.wait_for(llm.ainvoke(messages), timeout=60)
 
-        # 4. Parse and Validate
-        # Clean markdown formatting if present
-        clean_json = response.content.strip()
+		# 4. Parse and Validate
+		# Clean markdown formatting if present
+		clean_json = response.content.strip()
 
-        if clean_json.startswith("```json"):
-            clean_json = clean_json.removeprefix("```json").removesuffix("```").strip()
-        elif clean_json.startswith("```"):
-            clean_json = clean_json.removeprefix("```").removesuffix("```").strip()
+		if clean_json.startswith("```json"):
+			clean_json = clean_json.removeprefix("```json").removesuffix("```").strip()
+		elif clean_json.startswith("```"):
+			clean_json = clean_json.removeprefix("```").removesuffix("```").strip()
 
-        data = json.loads(clean_json)
+		data = json.loads(clean_json)
 
-        if isinstance(data, dict) and "recipes" in data:
-            return data["recipes"]
+		if isinstance(data, dict) and "recipes" in data:
+			return data["recipes"]
 
-        return data
+		return data
 
-    except asyncio.TimeoutError:
-        raise HTTPException(status_code=504, detail={"message": "LLM connection timed out."})
-    except Exception as e:
-        traceback.print_exc()
-        raise HTTPException(status_code=500, detail={"message": str(e)})
+	except asyncio.TimeoutError:
+		raise HTTPException(
+			status_code=504, detail={"message": "LLM connection timed out."}
+		)
+	except Exception as e:
+		traceback.print_exc()
+		raise HTTPException(status_code=500, detail={"message": str(e)})

--- a/services/py-recipe-service/requirements.txt
+++ b/services/py-recipe-service/requirements.txt
@@ -1,10 +1,10 @@
 fastapi==0.111.0
 uvicorn==0.30.1
-langchain
-langchain-openai
+langchain==1.3.11
+langchain-openai==1.3.3
 langchain-google-genai==2.1.12
-langchain-core==1.4.0
+langchain-core==1.4.7
 pydantic==2.7.4
 python-dotenv==1.0.1
-attrs
-python-dateutil
+attrs==23.2.0
+python-dateutil==2.9.0.post0

--- a/services/py-recipe-service/requirements.txt
+++ b/services/py-recipe-service/requirements.txt
@@ -1,9 +1,10 @@
 fastapi==0.111.0
 uvicorn==0.30.1
+langchain
+langchain-openai
 langchain-google-genai==2.1.12
 langchain-core==1.4.0
 pydantic==2.7.4
 python-dotenv==1.0.1
 attrs
-httpx
 python-dateutil

--- a/services/spring-api/src/main/kotlin/org/openapitools/config/AiConfig.kt
+++ b/services/spring-api/src/main/kotlin/org/openapitools/config/AiConfig.kt
@@ -29,6 +29,7 @@ class AiConfig {
 		OkHttpClient
 			.Builder()
 			.connectionPool(ConnectionPool(5, 2, TimeUnit.SECONDS))
+        	.readTimeout(60, TimeUnit.SECONDS) // Time allowed for Python to process and stream back data
 			.callTimeout(60, TimeUnit.SECONDS)
 			.addInterceptor(InternalHmacInterceptor(internalAuthSecret))
 			.build()

--- a/services/spring-api/src/main/kotlin/org/openapitools/config/AiConfig.kt
+++ b/services/spring-api/src/main/kotlin/org/openapitools/config/AiConfig.kt
@@ -29,7 +29,7 @@ class AiConfig {
 		OkHttpClient
 			.Builder()
 			.connectionPool(ConnectionPool(5, 2, TimeUnit.SECONDS))
-        	.readTimeout(60, TimeUnit.SECONDS) // Time allowed for Python to process and stream back data
+			.readTimeout(60, TimeUnit.SECONDS) // Time allowed for Python to process and stream back data
 			.callTimeout(60, TimeUnit.SECONDS)
 			.addInterceptor(InternalHmacInterceptor(internalAuthSecret))
 			.build()


### PR DESCRIPTION
## Summary

Setup logos support

New env variables `PROVIDER` toggles between `google_genai`, `openai` (Logos) in local deployment and for K8s deployment. Right now it is set to `google_genai` on GH for K8s deployment as it performs better (faster, and no markdown mistakes).

Azure VM can not use Logos as it is not inside the TUM network.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Infrastructure / CI
- [ ] Documentation

## API changes

- [x] This PR does not affect the API
- [ ] This PR changes the API → `api/openapi.yaml` updated and `api/scripts/gen-all.sh` re-run

## Definition of Done

- [x] CI passes
- [x] Pre-commit hooks pass locally
- [ ] Relevant tests added or updated
