### PR TITLE
Scale ingredients and nutrients in AI help request

### DIFF
--- a/web-client/src/pages/RecipePage.tsx
+++ b/web-client/src/pages/RecipePage.tsx
@@ -186,6 +186,17 @@ function RecipeView({
 	const scale = recipe.portions ? portions / recipe.portions : 1
 	const pages = pagination && pagination.count > 1 ? pagination : null
 
+	const scaledIngredients = recipe.ingredients.map((ing) => ({
+		...ing,
+		quantity: ing.quantity != null ? ing.quantity * scale : ing.quantity,
+	}))
+	const scaledNutrients = recipe.nutrients && {
+		calories: recipe.nutrients.calories != null ? Math.round(recipe.nutrients.calories * scale) : recipe.nutrients.calories,
+		protein: recipe.nutrients.protein != null ? Math.round(recipe.nutrients.protein * scale) : recipe.nutrients.protein,
+		fat: recipe.nutrients.fat != null ? Math.round(recipe.nutrients.fat * scale) : recipe.nutrients.fat,
+		carbs: recipe.nutrients.carbs != null ? Math.round(recipe.nutrients.carbs * scale) : recipe.nutrients.carbs,
+	}
+
 	async function handleGetHelp() {
 		const question = helpPrompt.trim()
 		if (question === '') return
@@ -196,17 +207,9 @@ function RecipeView({
 			const body: HelpRequest = {
 				recipe: {
 					title: recipe.title,
-					ingredients: recipe.ingredients.map((ing) => ({
-						...ing,
-						quantity: ing.quantity != null ? ing.quantity * scale : ing.quantity,
-					})),
+					ingredients: scaledIngredients,
 					instructions: recipe.instructions,
-					nutrients: recipe.nutrients && {
-						calories: recipe.nutrients.calories != null ? Math.round(recipe.nutrients.calories * scale) : recipe.nutrients.calories,
-						protein: recipe.nutrients.protein != null ? Math.round(recipe.nutrients.protein * scale) : recipe.nutrients.protein,
-						fat: recipe.nutrients.fat != null ? Math.round(recipe.nutrients.fat * scale) : recipe.nutrients.fat,
-						carbs: recipe.nutrients.carbs != null ? Math.round(recipe.nutrients.carbs * scale) : recipe.nutrients.carbs,
-					},
+					nutrients: scaledNutrients,
 					portions,
 				},
 				prompt: question,
@@ -309,7 +312,7 @@ function RecipeView({
 				<div>
 					<h3 className="font-medium">{t('recipe.ingredients')}</h3>
 					<ul className="flex flex-col gap-1">
-						{recipe.ingredients.map((ing, j) => {
+						{scaledIngredients.map((ing, j) => {
 							const checked = checkedIngredients.has(j)
 							return (
 								<li key={j}>
@@ -321,7 +324,7 @@ function RecipeView({
 										/>
 										<span className={checked ? 'line-through text-gray-400 dark:text-neutral-500' : ''}>
 											{[
-												ing.quantity != null ? formatQuantity(ing.quantity, scale) : null,
+												ing.quantity != null ? formatQuantity(ing.quantity) : null,
 												ing.unit,
 												ing.name,
 											]
@@ -358,12 +361,12 @@ function RecipeView({
 				</div>
 
 				{/* Nutrients */}
-				{recipe.nutrients && (
+				{scaledNutrients && (
 					<div className="flex flex-wrap gap-x-4 gap-y-1 text-sm text-gray-600 dark:text-neutral-300">
-						{recipe.nutrients.calories != null && <span>{t('common.kcal', { value: Math.round(recipe.nutrients.calories * scale) })}</span>}
-						{recipe.nutrients.protein != null && <span>{t('common.protein', { value: Math.round(recipe.nutrients.protein * scale) })}</span>}
-						{recipe.nutrients.fat != null && <span>{t('common.fat', { value: Math.round(recipe.nutrients.fat * scale) })}</span>}
-						{recipe.nutrients.carbs != null && <span>{t('common.carbs', { value: Math.round(recipe.nutrients.carbs * scale) })}</span>}
+						{scaledNutrients.calories != null && <span>{t('common.kcal', { value: scaledNutrients.calories })}</span>}
+						{scaledNutrients.protein != null && <span>{t('common.protein', { value: scaledNutrients.protein })}</span>}
+						{scaledNutrients.fat != null && <span>{t('common.fat', { value: scaledNutrients.fat })}</span>}
+						{scaledNutrients.carbs != null && <span>{t('common.carbs', { value: scaledNutrients.carbs })}</span>}
 					</div>
 				)}
 			</article>

--- a/web-client/src/pages/RecipePage.tsx
+++ b/web-client/src/pages/RecipePage.tsx
@@ -196,9 +196,17 @@ function RecipeView({
 			const body: HelpRequest = {
 				recipe: {
 					title: recipe.title,
-					ingredients: recipe.ingredients,
+					ingredients: recipe.ingredients.map((ing) => ({
+						...ing,
+						quantity: ing.quantity != null ? ing.quantity * scale : ing.quantity,
+					})),
 					instructions: recipe.instructions,
-					nutrients: recipe.nutrients,
+					nutrients: recipe.nutrients && {
+						calories: recipe.nutrients.calories != null ? Math.round(recipe.nutrients.calories * scale) : recipe.nutrients.calories,
+						protein: recipe.nutrients.protein != null ? Math.round(recipe.nutrients.protein * scale) : recipe.nutrients.protein,
+						fat: recipe.nutrients.fat != null ? Math.round(recipe.nutrients.fat * scale) : recipe.nutrients.fat,
+						carbs: recipe.nutrients.carbs != null ? Math.round(recipe.nutrients.carbs * scale) : recipe.nutrients.carbs,
+					},
 					portions,
 				},
 				prompt: question,

--- a/web-client/tests/pages/RecipePage.test.tsx
+++ b/web-client/tests/pages/RecipePage.test.tsx
@@ -67,6 +67,7 @@ function renderLibraryRecipe(recipeId: number, ids?: number[]) {
 describe('RecipePage', () => {
 	it('scales ingredient quantities and kcal when portions are doubled', async () => {
 		const user = userEvent.setup()
+		fetchMock.mockResolvedValueOnce(jsonResponse({response: 'sure'}))
 		renderGeneratedRecipe(0)
 
 		// baseline: 4 pcs tomato, 500 kcal at 2 portions
@@ -81,6 +82,16 @@ describe('RecipePage', () => {
 
 		expect(screen.getByText(/8 pcs tomato/i)).toBeInTheDocument()
 		expect(screen.getByText('1000 kcal')).toBeInTheDocument()
+
+		// the same scaled values must reach the help request, not the originals
+		await user.type(screen.getByPlaceholderText(/.+/), 'can I swap the tomato?')
+		await user.click(screen.getByRole('button', {name: 'Get help'}))
+
+		const [, options] = fetchMock.mock.calls.find(([url]) => String(url).includes('/ai/help'))!
+		const body = JSON.parse(String(options!.body))
+		expect(body.recipe.portions).toBe(4)
+		expect(body.recipe.ingredients).toEqual([{name: 'tomato', quantity: 8, unit: 'pcs'}])
+		expect(body.recipe.nutrients).toEqual({calories: 1000, protein: 40, fat: 20, carbs: 120})
 	})
 
 	it('disables Previous on the first recipe and Next on the last', () => {


### PR DESCRIPTION
## Summary

Fixes #70. When asking the AI for help, the request used the *updated* portion count but kept the *original, unscaled* ingredient quantities and nutrient values, so the AI received a recipe whose portions didn't match its ingredients/nutrients.

In `RecipePage.handleGetHelp`, ingredient quantities and nutrient values are now scaled by the same `scale` factor (`portions / recipe.portions`) already used for on-screen display before the request body is built. Null quantities/values are preserved as-is; nutrients are rounded to match the displayed numbers. When portions are unchanged, `scale` is 1 and the request is identical to before.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Infrastructure / CI
- [ ] Documentation

## API changes

- [x] This PR does not affect the API
- [ ] This PR changes the API → `api/openapi.yaml` updated and `api/scripts/gen-all.sh` re-run

## Definition of Done

- [x] CI passes
- [x] Pre-commit hooks pass locally
- [x] Relevant tests added or updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
