### PR TITLE
Add clear-selection button and fix results header inputs on /generate

### DIFF
--- a/web-client/src/locales/de.ts
+++ b/web-client/src/locales/de.ts
@@ -106,6 +106,7 @@ export const DE = {
 			noRecipes: 'Keine Rezepte erhalten.',
 			generating: 'Wird erstellt…',
 			generate: 'Erstellen',
+			clear: 'Auswahl löschen',
 		},
 		library: {
 			emptyTitle: 'Dein Kochbuch ist leer',

--- a/web-client/src/locales/en.ts
+++ b/web-client/src/locales/en.ts
@@ -106,6 +106,7 @@ export const EN = {
 			noRecipes: 'No recipes returned.',
 			generating: 'Generating…',
 			generate: 'Generate',
+			clear: 'Clear selection',
 		},
 		library: {
 			emptyTitle: 'Your cookbook is empty',

--- a/web-client/src/locales/hu.ts
+++ b/web-client/src/locales/hu.ts
@@ -106,6 +106,7 @@ export const HU = {
 			noRecipes: 'Nem érkezett recept.',
 			generating: 'Készül…',
 			generate: 'Készítés',
+			clear: 'Kijelölés törlése',
 		},
 		library: {
 			emptyTitle: 'Nincs még elmentett recepted',

--- a/web-client/src/pages/GeneratePage.tsx
+++ b/web-client/src/pages/GeneratePage.tsx
@@ -198,7 +198,11 @@ export function GeneratePage() {
 export function GenerateResultsPage() {
 	const {t, i18n} = useTranslation()
 	const navigate = useNavigate()
-	const {prompt, selectedTags, recipes, status, setRecipes} = useOutletContext<RecipeGenerationContext>()
+	const {recipes, status, setRecipes} = useOutletContext<RecipeGenerationContext>()
+
+	// read from sessionStorage instead of context so unsaved edits are not shown the results header
+	const lastPrompt = sessionStorage.getItem('recipe_prompt') ?? ''
+	const lastTags = JSON.parse(sessionStorage.getItem('recipe_tags') ?? '[]') as string[]
 
 	function handleSavedIdChange(index: number, newId: number | undefined) {
 		setRecipes((prev) => prev.map((prevRecipe, prevIndex) => (prevIndex === index ? {
@@ -211,10 +215,10 @@ export function GenerateResultsPage() {
 		<>
 			<div className="flex items-start justify-between gap-3 rounded-lg border border-gray-200 dark:border-neutral-700 bg-gray-50 dark:bg-neutral-800 p-3">
 				<div className="flex min-w-0 flex-col gap-2">
-					{prompt.trim() !== '' && <p className="text-sm text-gray-700 dark:text-neutral-200 line-clamp-2">{prompt}</p>}
-					{selectedTags.length > 0 && (
+					{lastPrompt.trim() !== '' && <p className="text-sm text-gray-700 dark:text-neutral-200 line-clamp-2">{lastPrompt}</p>}
+					{lastTags.length > 0 && (
 						<div className="flex flex-wrap gap-1.5">
-							{selectedTags.map((id) => (
+							{lastTags.map((id) => (
 								<span key={id}
 								      className="rounded-full border border-gray-200 dark:border-neutral-700 bg-white dark:bg-neutral-800 px-2 py-0.5 text-xs text-gray-600 dark:text-neutral-300">
 									{localizeTagLabel(id, tagsById.get(id)?.label ?? id, i18n.language)}
@@ -222,7 +226,7 @@ export function GenerateResultsPage() {
 							))}
 						</div>
 					)}
-					{prompt.trim() === '' && selectedTags.length === 0 && (
+					{lastPrompt.trim() === '' && lastTags.length === 0 && (
 						<p className="text-sm text-gray-400 dark:text-neutral-500">{t('generate.noOptions')}</p>
 					)}
 				</div>

--- a/web-client/src/pages/GeneratePage.tsx
+++ b/web-client/src/pages/GeneratePage.tsx
@@ -2,7 +2,7 @@ import {useEffect, useState} from 'react'
 import type {Dispatch, SetStateAction} from 'react'
 import {Outlet, useLocation, useNavigate, useOutletContext} from 'react-router-dom'
 import {useTranslation} from 'react-i18next'
-import {ChevronRightIcon, PencilSquareIcon} from '@heroicons/react/24/outline'
+import {ChevronRightIcon, PencilSquareIcon, XMarkIcon} from '@heroicons/react/24/outline'
 import type {components} from '../api'
 import {Button} from '../components/Button'
 import {RecipeCard} from '../components/RecipeCard'
@@ -166,15 +166,31 @@ export function GeneratePage() {
 
 			<TagSelector selectedTags={selectedTags} onChange={setSelectedTags}/>
 
-			<Button
-				ref={generateBtnRef}
-				type="button"
-				className="self-center"
-				onClick={generate}
-				disabled={loading || (prompt.trim() === '' && selectedTags.length === 0)}
-			>
-				{loading ? t('generate.generating') : t('generate.generate')}
-			</Button>
+			<div className="flex flex-col items-center gap-3">
+				{/* Clear selection button */}
+				<button
+					type="button"
+					className="flex items-center gap-1 text-sm text-gray-500 dark:text-neutral-400 cursor-pointer transition-transform duration-100 hover:scale-98 disabled:cursor-default disabled:opacity-40 disabled:hover:scale-100"
+					onClick={() => {
+						setPrompt('')
+						setSelectedTags([])
+					}}
+					disabled={prompt.trim() === '' && selectedTags.length === 0}
+				>
+					<XMarkIcon className="h-4 w-4"/>
+					{t('generate.clear')}
+				</button>
+
+				{/* Generate button */}
+				<Button
+					ref={generateBtnRef}
+					type="button"
+					onClick={generate}
+					disabled={loading || (prompt.trim() === '' && selectedTags.length === 0)}
+				>
+					{loading ? t('generate.generating') : t('generate.generate')}
+				</Button>
+			</div>
 		</>
 	)
 }

--- a/web-client/tests/pages/GeneratePage.test.tsx
+++ b/web-client/tests/pages/GeneratePage.test.tsx
@@ -98,6 +98,27 @@ describe('GeneratePage', () => {
 		expect(clear).toBeDisabled()
 	})
 
+	it('keeps the results header showing the generated inputs after later edits', async () => {
+		fetchMock.mockResolvedValueOnce(jsonResponse([recipe]))
+		const user = userEvent.setup()
+		render()
+
+		await user.type(screen.getByPlaceholderText(/Type what you think/i), 'pasta')
+		await user.click(screen.getByRole('button', { name: 'Generate' }))
+		expect(await screen.findByText('pasta')).toBeInTheDocument()
+
+		// go back, edit the prompt, and return without regenerating
+		await user.click(screen.getByRole('button', { name: 'Edit' }))
+		const input = screen.getByPlaceholderText(/Type what you think/i)
+		await user.clear(input)
+		await user.type(input, 'soup')
+		await user.click(screen.getByRole('button', { name: 'View recipes' }))
+
+		// the header reflects what was generated, not the unsaved edit
+		expect(screen.getByText('pasta')).toBeInTheDocument()
+		expect(screen.queryByText('soup')).not.toBeInTheDocument()
+	})
+
 	it('shows a server error on the results page', async () => {
 		fetchMock.mockResolvedValueOnce(jsonResponse({ message: 'GenAI down' }, { status: 503 }))
 		const user = userEvent.setup()

--- a/web-client/tests/pages/GeneratePage.test.tsx
+++ b/web-client/tests/pages/GeneratePage.test.tsx
@@ -79,6 +79,25 @@ describe('GeneratePage', () => {
 		})
 	})
 
+	it('clears the prompt and selected tags via the clear button', async () => {
+		const user = userEvent.setup()
+		render()
+
+		const clear = screen.getByRole('button', { name: 'Clear selection' })
+		expect(clear).toBeDisabled()
+
+		const prompt = screen.getByPlaceholderText(/Type what you think/i)
+		await user.type(prompt, 'pasta')
+		await user.click(screen.getByRole('button', { name: 'Dinner' }))
+		expect(clear).toBeEnabled()
+
+		await user.click(clear)
+
+		expect(prompt).toHaveValue('')
+		expect(screen.queryByRole('button', { name: 'Curry' })).not.toBeInTheDocument()
+		expect(clear).toBeDisabled()
+	})
+
 	it('shows a server error on the results page', async () => {
 		fetchMock.mockResolvedValueOnce(jsonResponse({ message: 'GenAI down' }, { status: 503 }))
 		const user = userEvent.setup()


### PR DESCRIPTION
## Summary

Two related improvements to the `/generate` page:

- **Clear-selection button.** A plain-text "Clear selection" control (X icon + label, no button chrome) sits above the Generate button. It resets both the prompt text and the selected tags, and is disabled while there is no input.
- **Results header reflects the generated inputs.** Previously the summary shown above the results got edited if the user edited the prompt without actually generating new recipes, which was unexpected - it showed a new prompt with old results.

Translations for the new label added in EN/DE/HU.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Infrastructure / CI
- [ ] Documentation

## API changes

- [x] This PR does not affect the API
- [ ] This PR changes the API → `api/openapi.yaml` updated and `api/scripts/gen-all.sh` re-run

## Definition of Done

- [x] CI passes
- [x] Pre-commit hooks pass locally
- [x] Relevant tests added or updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
