### PR TITLE
Grafana logs, alerting, and dashboards

### DIFF
--- a/.github/workflows/deploy-k8s.yml
+++ b/.github/workflows/deploy-k8s.yml
@@ -118,6 +118,8 @@ jobs:
         run: |
           kubectl rollout status deployment/prometheus -n monitoring --timeout=300s
           kubectl rollout status deployment/grafana -n monitoring --timeout=180s
+          kubectl rollout status deployment/loki -n monitoring --timeout=180s
+          kubectl rollout status deployment/alloy -n monitoring --timeout=120s
 
       - name: Restart deployments to pull latest images
         if: github.event_name != 'push'

--- a/.github/workflows/deploy-k8s.yml
+++ b/.github/workflows/deploy-k8s.yml
@@ -60,6 +60,7 @@ jobs:
       #   HELP_SERVICE_KEY       — Gemini API key for py-help-service
       #   RECIPE_SERVICE_KEY     — Gemini API key for py-recipe-service
       #   GRAFANA_ADMIN_PASSWORD — Grafana admin password
+      #   DISCORD_WEBHOOK_URL    — Discord webhook URL for Grafana alert notifications
       #   KUBE_CONFIG            — base64-encoded kubeconfig (base64 -w0 on Linux)
       - name: Upsert K8s secrets
         run: |
@@ -95,6 +96,10 @@ jobs:
 
           kubectl create secret generic grafana-secret -n monitoring \
             --from-literal=admin-password="${{ secrets.GRAFANA_ADMIN_PASSWORD }}" \
+            --dry-run=client -o yaml | kubectl apply -f -
+
+          kubectl create secret generic grafana-discord-secret -n monitoring \
+            --from-literal=webhook-url="${{ secrets.DISCORD_WEBHOOK_URL }}" \
             --dry-run=client -o yaml | kubectl apply -f -
 
       - name: Deploy PostgreSQL (StatefulSet)

--- a/.github/workflows/deploy-k8s.yml
+++ b/.github/workflows/deploy-k8s.yml
@@ -119,6 +119,12 @@ jobs:
       - name: Deploy monitoring
         run: kubectl apply -f infra/k8s/monitoring/
 
+      - name: Restart monitoring to reload ConfigMap-based config
+        run: |
+          kubectl rollout restart deployment/grafana -n monitoring
+          kubectl rollout restart deployment/loki -n monitoring
+          kubectl rollout restart deployment/alloy -n monitoring
+
       - name: Wait for monitoring rollouts
         run: |
           kubectl rollout status deployment/prometheus -n monitoring --timeout=300s

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Coverage reports: https://aet-devops26.github.io/team-devsecops/
 
 API scheme (Swagger UI): https://devsecops.stud.k8s.aet.cit.tum.de/swagger-ui/index.html
 
-Monitoring (Grafana): https://devsecops.stud.k8s.aet.cit.tum.de/grafana
+Monitoring (Grafana): https://grafana.devsecops.stud.k8s.aet.cit.tum.de
 ## Local development
 
 The full stack runs under Docker Compose with live-reload:

--- a/infra/k8s/monitoring/alloy.yaml
+++ b/infra/k8s/monitoring/alloy.yaml
@@ -143,6 +143,13 @@ spec:
           ports:
             - name: http
               containerPort: 12345
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 6
           volumeMounts:
             - name: config
               mountPath: /etc/alloy

--- a/infra/k8s/monitoring/alloy.yaml
+++ b/infra/k8s/monitoring/alloy.yaml
@@ -1,0 +1,163 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: alloy
+  namespace: monitoring
+---
+# Namespace-scoped Role in monitoring — grants Alloy permission to read pod
+# metadata and stream logs via the K8s API within this namespace.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: alloy-log-reader
+  namespace: monitoring
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "pods/log"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: alloy-log-reader
+  namespace: monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: alloy-log-reader
+subjects:
+  - kind: ServiceAccount
+    name: alloy
+    namespace: monitoring
+---
+# Same Role in app namespace — the ServiceAccount lives in monitoring but
+# RoleBindings can reference subjects from any namespace.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: alloy-log-reader
+  namespace: app
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "pods/log"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: alloy-log-reader
+  namespace: app
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: alloy-log-reader
+subjects:
+  - kind: ServiceAccount
+    name: alloy
+    namespace: monitoring
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: alloy-config
+  namespace: monitoring
+data:
+  config.alloy: |
+    // Discover pods only in the namespaces we have permission to read.
+    // Scoping discovery here avoids needing cluster-wide ClusterRole.
+    discovery.kubernetes "pods" {
+      role = "pod"
+      namespaces {
+        names = ["app", "monitoring"]
+      }
+    }
+
+    // Map pod metadata to Loki stream labels
+    discovery.relabel "pods" {
+      targets = discovery.kubernetes.pods.targets
+
+      rule {
+        source_labels = ["__meta_kubernetes_namespace"]
+        target_label  = "namespace"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_name"]
+        target_label  = "pod"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_container_name"]
+        target_label  = "container"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_label_app"]
+        target_label  = "app"
+      }
+      // Grafana Logs Drilldown follows OTel convention and groups by service_name
+      rule {
+        source_labels = ["__meta_kubernetes_pod_label_app"]
+        target_label  = "service_name"
+      }
+    }
+
+    // Tail logs from each discovered pod via the K8s log streaming API
+    loki.source.kubernetes "pods" {
+      targets    = discovery.relabel.pods.output
+      forward_to = [loki.write.local.receiver]
+    }
+
+    // Push collected logs to Loki
+    loki.write "local" {
+      endpoint {
+        url = "http://loki.monitoring.svc.cluster.local:3100/loki/api/v1/push"
+      }
+    }
+---
+# Single Deployment (not DaemonSet) — loki.source.kubernetes reads logs via the
+# K8s API, so one pod is sufficient regardless of how many nodes the cluster has.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: alloy
+  namespace: monitoring
+spec:
+  replicas: 1
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: alloy
+  template:
+    metadata:
+      labels:
+        app: alloy
+    spec:
+      serviceAccountName: alloy
+      containers:
+        - name: alloy
+          image: grafana/alloy:v1.7.1
+          args:
+            - run
+            - /etc/alloy/config.alloy
+            - --storage.path=/var/lib/alloy/data
+            - --server.http.listen-addr=0.0.0.0:12345
+          ports:
+            - name: http
+              containerPort: 12345
+          volumeMounts:
+            - name: config
+              mountPath: /etc/alloy
+            - name: data
+              mountPath: /var/lib/alloy/data
+          resources:
+            requests:
+              cpu: 30m
+              memory: 64Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+      volumes:
+        - name: config
+          configMap:
+            name: alloy-config
+        - name: data
+          emptyDir: {}

--- a/infra/k8s/monitoring/grafana-alerting.yaml
+++ b/infra/k8s/monitoring/grafana-alerting.yaml
@@ -1,0 +1,213 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-alerting
+  namespace: monitoring
+data:
+  templates.yaml: |
+    apiVersion: 1
+    templates:
+      - orgId: 1
+        name: discord-message
+        template: |
+          {{ define "discord-message" -}}
+          {{ range .Alerts -}}
+          {{ if eq .Status "firing" -}}
+          **{{ .Labels.alertname }}{{ if .Labels.service }} — {{ .Labels.service }}{{ end }}**
+          Status: 🔴 FIRING
+          {{ else -}}
+          **{{ .Labels.alertname }}{{ if .Labels.service }} — {{ .Labels.service }}{{ end }}**
+          Status: ✅ RESOLVED
+          {{ end -}}
+          {{ if .Annotations.value }}Value: {{ .Annotations.value }}
+          {{ end -}}
+          {{ if .Annotations.description }}{{ .Annotations.description }}
+          {{ end -}}
+          {{ if .GeneratorURL }}[View Alert]({{ .GeneratorURL }}){{ end }}
+          {{ end -}}
+          {{ end }}
+
+  contactpoints.yaml: |
+    apiVersion: 1
+    contactPoints:
+      - orgId: 1
+        name: discord-alerts
+        receivers:
+          - uid: discord-main
+            type: discord
+            disableResolveMessage: false
+            settings:
+              # Grafana substitutes ${VAR} from the container environment at startup.
+              # DISCORD_WEBHOOK_URL is injected from grafana-discord-secret.
+              url: ${DISCORD_WEBHOOK_URL}
+              message: '{{ template "discord-message" . }}'
+
+  notificationpolicies.yaml: |
+    apiVersion: 1
+    policies:
+      - orgId: 1
+        receiver: discord-alerts
+        group_by: ['alertname', 'service']
+        group_wait: 30s
+        group_interval: 5m
+        repeat_interval: 4h
+        routes:
+          - receiver: discord-alerts
+            matchers:
+              - severity = critical
+            group_wait: 0s
+            repeat_interval: 1h
+
+  alertrules.yaml: |
+    apiVersion: 1
+    groups:
+      - orgId: 1
+        name: api-health
+        folder: Alerting Rules
+        interval: 1m
+        rules:
+
+          # Fires when the Spring API 5xx error rate exceeds 5% for 5 consecutive minutes.
+          - uid: spring-api-high-error-rate
+            title: "High Error Rate — Spring API"
+            condition: B
+            data:
+              - refId: A
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: prometheus
+                model:
+                  datasource:
+                    type: prometheus
+                    uid: prometheus
+                  expr: '100 * sum(rate(http_server_requests_seconds_count{job="spring-api",outcome="SERVER_ERROR"}[5m])) / sum(rate(http_server_requests_seconds_count{job="spring-api"}[5m]))'
+                  instant: true
+                  refId: A
+              - refId: B
+                datasourceUid: "__expr__"
+                model:
+                  conditions:
+                    - evaluator:
+                        params: [5]
+                        type: gt
+                      operator:
+                        type: and
+                      query:
+                        params: [A]
+                      reducer:
+                        params: []
+                        type: last
+                      type: query
+                  datasource:
+                    type: __expr__
+                    uid: "__expr__"
+                  refId: B
+                  type: classic_conditions
+            noDataState: OK
+            execErrState: Error
+            for: 5m
+            annotations:
+              summary: "Spring API 5xx error rate exceeded 5%"
+              description: "The server error rate has been above 5% for 5 consecutive minutes."
+            labels:
+              severity: warning
+              service: spring-api
+
+          # Fires when the Spring API P95 response time exceeds 2 seconds for 5 consecutive minutes.
+          - uid: spring-api-high-latency
+            title: "High P95 Latency — Spring API"
+            condition: B
+            data:
+              - refId: A
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: prometheus
+                model:
+                  datasource:
+                    type: prometheus
+                    uid: prometheus
+                  expr: 'histogram_quantile(0.95, sum(rate(http_server_requests_seconds_bucket{job="spring-api"}[5m])) by (le))'
+                  instant: true
+                  refId: A
+              - refId: B
+                datasourceUid: "__expr__"
+                model:
+                  conditions:
+                    - evaluator:
+                        params: [2]
+                        type: gt
+                      operator:
+                        type: and
+                      query:
+                        params: [A]
+                      reducer:
+                        params: []
+                        type: last
+                      type: query
+                  datasource:
+                    type: __expr__
+                    uid: "__expr__"
+                  refId: B
+                  type: classic_conditions
+            noDataState: OK
+            execErrState: Error
+            for: 5m
+            annotations:
+              summary: "Spring API P95 latency exceeded 2 seconds"
+              description: "95th percentile response time has been above 2s for 5 consecutive minutes."
+            labels:
+              severity: warning
+              service: spring-api
+
+          # Fires one alert instance per service when Prometheus cannot scrape it.
+          # Uses reduce+math (not classic_conditions) so each firing instance carries
+          # the job label, making it clear which service is down.
+          # noDataState: Alerting fires even when the target disappears from Prometheus entirely.
+          - uid: service-down
+            title: "Service Down"
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: prometheus
+                model:
+                  datasource:
+                    type: prometheus
+                    uid: prometheus
+                  expr: 'up{job=~"spring-api|py-help-service|py-recipe-service"}'
+                  instant: true
+                  refId: A
+              - refId: B
+                datasourceUid: "__expr__"
+                model:
+                  datasource:
+                    type: __expr__
+                    uid: "__expr__"
+                  expression: A
+                  reducer: last
+                  settings:
+                    mode: dropNN
+                  refId: B
+                  type: reduce
+              - refId: C
+                datasourceUid: "__expr__"
+                model:
+                  datasource:
+                    type: __expr__
+                    uid: "__expr__"
+                  expression: $B < 1
+                  refId: C
+                  type: math
+            noDataState: Alerting
+            execErrState: Alerting
+            for: 2m
+            annotations:
+              summary: "Service Down — {{ $labels.job }}"
+              description: "Prometheus cannot scrape {{ $labels.job }} for 2+ minutes. Pod may be down or in a crash loop."
+            labels:
+              severity: critical

--- a/infra/k8s/monitoring/grafana-dashboards.yaml
+++ b/infra/k8s/monitoring/grafana-dashboards.yaml
@@ -1,0 +1,559 @@
+---
+# Dashboard provider: tells Grafana to load JSON files from /etc/grafana/dashboards.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-provider
+  namespace: monitoring
+data:
+  dashboards.yaml: |
+    apiVersion: 1
+    providers:
+      - name: default
+        orgId: 1
+        type: file
+        disableDeletion: true
+        updateIntervalSeconds: 30
+        allowUiUpdates: false
+        options:
+          path: /etc/grafana/dashboards
+          foldersFromFilesStructure: false
+---
+# Dashboard JSON: Services Overview (service health + Spring API metrics + logs).
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-services
+  namespace: monitoring
+data:
+  services-overview.json: |
+    {
+      "annotations": {"list": []},
+      "editable": false,
+      "graphTooltip": 1,
+      "id": null,
+      "links": [],
+      "panels": [
+        {
+          "id": 1,
+          "type": "stat",
+          "title": "spring-api",
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "gridPos": {"h": 4, "w": 8, "x": 0, "y": 0},
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "thresholds"},
+              "mappings": [{"type": "value", "options": {"0": {"text": "DOWN", "color": "red", "index": 1}, "1": {"text": "UP", "color": "green", "index": 0}}}],
+              "thresholds": {"mode": "absolute", "steps": [{"color": "red", "value": null}, {"color": "green", "value": 1}]}
+            },
+            "overrides": []
+          },
+          "options": {"colorMode": "background", "graphMode": "none", "justifyMode": "center", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto", "wideLayout": true},
+          "targets": [{"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "up{job=\"spring-api\"}", "instant": true, "refId": "A"}]
+        },
+        {
+          "id": 2,
+          "type": "stat",
+          "title": "py-help-service",
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "gridPos": {"h": 4, "w": 8, "x": 8, "y": 0},
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "thresholds"},
+              "mappings": [{"type": "value", "options": {"0": {"text": "DOWN", "color": "red", "index": 1}, "1": {"text": "UP", "color": "green", "index": 0}}}],
+              "thresholds": {"mode": "absolute", "steps": [{"color": "red", "value": null}, {"color": "green", "value": 1}]}
+            },
+            "overrides": []
+          },
+          "options": {"colorMode": "background", "graphMode": "none", "justifyMode": "center", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto", "wideLayout": true},
+          "targets": [{"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "up{job=\"py-help-service\"}", "instant": true, "refId": "A"}]
+        },
+        {
+          "id": 3,
+          "type": "stat",
+          "title": "py-recipe-service",
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "gridPos": {"h": 4, "w": 8, "x": 16, "y": 0},
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "thresholds"},
+              "mappings": [{"type": "value", "options": {"0": {"text": "DOWN", "color": "red", "index": 1}, "1": {"text": "UP", "color": "green", "index": 0}}}],
+              "thresholds": {"mode": "absolute", "steps": [{"color": "red", "value": null}, {"color": "green", "value": 1}]}
+            },
+            "overrides": []
+          },
+          "options": {"colorMode": "background", "graphMode": "none", "justifyMode": "center", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto", "wideLayout": true},
+          "targets": [{"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "up{job=\"py-recipe-service\"}", "instant": true, "refId": "A"}]
+        },
+        {
+          "id": 4,
+          "type": "stat",
+          "title": "Request Rate",
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "gridPos": {"h": 4, "w": 6, "x": 0, "y": 4},
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "thresholds"},
+              "mappings": [],
+              "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "yellow", "value": 100}, {"color": "red", "value": 500}]},
+              "unit": "reqps"
+            },
+            "overrides": []
+          },
+          "options": {"colorMode": "value", "graphMode": "area", "justifyMode": "auto", "noValue": "0", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto", "wideLayout": true},
+          "targets": [{"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum(rate(http_server_requests_seconds_count{job=\"spring-api\"}[5m]))", "instant": true, "refId": "A"}]
+        },
+        {
+          "id": 5,
+          "type": "stat",
+          "title": "Error Rate",
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "gridPos": {"h": 4, "w": 6, "x": 6, "y": 4},
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "thresholds"},
+              "mappings": [{"type": "special", "options": {"match": "nan", "result": {"text": "N/A", "color": "blue", "index": 0}}}],
+              "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "yellow", "value": 1}, {"color": "red", "value": 5}]},
+              "unit": "percent",
+              "min": 0,
+              "max": 100
+            },
+            "overrides": []
+          },
+          "options": {"colorMode": "background", "graphMode": "area", "justifyMode": "auto", "noValue": "N/A", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto", "wideLayout": true},
+          "targets": [{"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "100 * (sum(rate(http_server_requests_seconds_count{job=\"spring-api\",outcome=\"SERVER_ERROR\"}[5m])) or on() vector(0)) / sum(rate(http_server_requests_seconds_count{job=\"spring-api\"}[5m]))", "instant": true, "refId": "A"}]
+        },
+        {
+          "id": 6,
+          "type": "stat",
+          "title": "P95 Latency",
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "gridPos": {"h": 4, "w": 6, "x": 12, "y": 4},
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "thresholds"},
+              "mappings": [{"type": "special", "options": {"match": "nan", "result": {"text": "N/A", "color": "blue", "index": 0}}}],
+              "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "yellow", "value": 0.5}, {"color": "red", "value": 2}]},
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "options": {"colorMode": "background", "graphMode": "area", "justifyMode": "auto", "noValue": "N/A", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto", "wideLayout": true},
+          "targets": [{"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "histogram_quantile(0.95, sum(rate(http_server_requests_seconds_bucket{job=\"spring-api\"}[5m])) by (le))", "instant": true, "refId": "A"}]
+        },
+        {
+          "id": 7,
+          "type": "stat",
+          "title": "JVM Heap",
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "gridPos": {"h": 4, "w": 6, "x": 18, "y": 4},
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "thresholds"},
+              "mappings": [],
+              "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "yellow", "value": 70}, {"color": "red", "value": 85}]},
+              "unit": "percent",
+              "min": 0,
+              "max": 100
+            },
+            "overrides": []
+          },
+          "options": {"colorMode": "background", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto", "wideLayout": true},
+          "targets": [{"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "100 * sum(jvm_memory_used_bytes{job=\"spring-api\",area=\"heap\"}) / sum(jvm_memory_max_bytes{job=\"spring-api\",area=\"heap\"})", "instant": true, "refId": "A"}]
+        },
+        {
+          "id": 8,
+          "type": "timeseries",
+          "title": "HTTP Requests by Outcome",
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "gridPos": {"h": 9, "w": 12, "x": 0, "y": 8},
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic"},
+              "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "req/s", "axisPlacement": "auto", "drawStyle": "line", "fillOpacity": 15, "gradientMode": "none", "lineWidth": 2, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "never", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}},
+              "mappings": [],
+              "thresholds": {"mode": "absolute", "steps": [{"color": "green"}]},
+              "unit": "reqps"
+            },
+            "overrides": [
+              {"matcher": {"id": "byName", "options": "5xx Errors"}, "properties": [{"id": "color", "value": {"fixedColor": "red", "mode": "fixed"}}]},
+              {"matcher": {"id": "byName", "options": "4xx Errors"}, "properties": [{"id": "color", "value": {"fixedColor": "orange", "mode": "fixed"}}]},
+              {"matcher": {"id": "byName", "options": "Success"}, "properties": [{"id": "color", "value": {"fixedColor": "green", "mode": "fixed"}}]}
+            ]
+          },
+          "options": {"legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+          "targets": [
+            {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum(rate(http_server_requests_seconds_count{job=\"spring-api\",outcome=\"SUCCESS\"}[5m]))", "legendFormat": "Success", "refId": "A"},
+            {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum(rate(http_server_requests_seconds_count{job=\"spring-api\",outcome=\"CLIENT_ERROR\"}[5m]))", "legendFormat": "4xx Errors", "refId": "B"},
+            {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum(rate(http_server_requests_seconds_count{job=\"spring-api\",outcome=\"SERVER_ERROR\"}[5m]))", "legendFormat": "5xx Errors", "refId": "C"}
+          ]
+        },
+        {
+          "id": 9,
+          "type": "timeseries",
+          "title": "Response Time Percentiles",
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "gridPos": {"h": 9, "w": 12, "x": 12, "y": 8},
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic"},
+              "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisPlacement": "auto", "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "lineWidth": 2, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "never", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "line+area"}},
+              "mappings": [],
+              "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "red", "value": 2}]},
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "options": {"legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+          "targets": [
+            {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "histogram_quantile(0.50, sum(rate(http_server_requests_seconds_bucket{job=\"spring-api\"}[5m])) by (le))", "legendFormat": "p50", "refId": "A"},
+            {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "histogram_quantile(0.90, sum(rate(http_server_requests_seconds_bucket{job=\"spring-api\"}[5m])) by (le))", "legendFormat": "p90", "refId": "B"},
+            {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "histogram_quantile(0.95, sum(rate(http_server_requests_seconds_bucket{job=\"spring-api\"}[5m])) by (le))", "legendFormat": "p95", "refId": "C"},
+            {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "histogram_quantile(0.99, sum(rate(http_server_requests_seconds_bucket{job=\"spring-api\"}[5m])) by (le))", "legendFormat": "p99", "refId": "D"}
+          ]
+        },
+        {
+          "id": 10,
+          "type": "timeseries",
+          "title": "JVM Memory",
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "gridPos": {"h": 9, "w": 12, "x": 0, "y": 17},
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic"},
+              "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisPlacement": "auto", "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "lineWidth": 1, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "never", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}},
+              "mappings": [],
+              "thresholds": {"mode": "absolute", "steps": [{"color": "green"}]},
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "options": {"legend": {"calcs": ["mean", "last"], "displayMode": "table", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "none"}},
+          "targets": [
+            {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum(jvm_memory_used_bytes{job=\"spring-api\"}) by (area)", "legendFormat": "used ({{area}})", "refId": "A"},
+            {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum(jvm_memory_max_bytes{job=\"spring-api\",area=\"heap\"})", "legendFormat": "max (heap)", "refId": "B"}
+          ]
+        },
+        {
+          "id": 11,
+          "type": "timeseries",
+          "title": "CPU Usage & JVM Threads",
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "gridPos": {"h": 9, "w": 12, "x": 12, "y": 17},
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic"},
+              "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisPlacement": "auto", "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "lineWidth": 1, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "never", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}},
+              "mappings": [],
+              "thresholds": {"mode": "absolute", "steps": [{"color": "green"}]},
+              "unit": "percentunit"
+            },
+            "overrides": [
+              {"matcher": {"id": "byName", "options": "Threads"}, "properties": [{"id": "unit", "value": "short"}, {"id": "custom.axisPlacement", "value": "right"}]}
+            ]
+          },
+          "options": {"legend": {"calcs": ["mean", "last"], "displayMode": "table", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "none"}},
+          "targets": [
+            {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "process_cpu_usage{job=\"spring-api\"}", "legendFormat": "CPU", "refId": "A"},
+            {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "jvm_threads_live_threads{job=\"spring-api\"}", "legendFormat": "Threads", "refId": "B"}
+          ]
+        },
+        {
+          "id": 12,
+          "type": "logs",
+          "title": "Error & Exception Logs",
+          "datasource": {"type": "loki", "uid": "loki"},
+          "gridPos": {"h": 8, "w": 24, "x": 0, "y": 26},
+          "fieldConfig": {"defaults": {}, "overrides": []},
+          "options": {
+            "dedupStrategy": "none",
+            "enableLogDetails": true,
+            "prettifyLogMessage": false,
+            "showCommonLabels": false,
+            "showLabels": false,
+            "showTime": true,
+            "sortOrder": "Descending",
+            "wrapLogMessage": true
+          },
+          "targets": [
+            {"datasource": {"type": "loki", "uid": "loki"}, "expr": "{namespace=\"app\"} |~ \"(?i)(error|exception|warn)\"", "refId": "A"}
+          ]
+        }
+      ],
+      "refresh": "30s",
+      "schemaVersion": 39,
+      "tags": ["spring-boot", "api", "services"],
+      "templating": {"list": []},
+      "time": {"from": "now-3h", "to": "now"},
+      "timepicker": {},
+      "timezone": "browser",
+      "title": "Services Overview",
+      "uid": "services-overview",
+      "version": 1,
+      "weekStart": ""
+    }
+  jvm-container-stats.json: |
+    {
+      "annotations": {"list": []},
+      "editable": false,
+      "graphTooltip": 1,
+      "id": null,
+      "links": [],
+      "panels": [
+        {
+          "id": 1,
+          "type": "gauge",
+          "title": "CPU Busy",
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "gridPos": {"h": 5, "w": 6, "x": 0, "y": 0},
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "thresholds"},
+              "mappings": [],
+              "max": 100,
+              "min": 0,
+              "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "yellow", "value": 60}, {"color": "red", "value": 80}]},
+              "unit": "percent"
+            },
+            "overrides": []
+          },
+          "options": {"minVizHeight": 75, "minVizWidth": 75, "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "showThresholdLabels": false, "showThresholdMarkers": true},
+          "targets": [{"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "process_cpu_usage{job=\"spring-api\"} * 100", "instant": true, "legendFormat": "CPU", "refId": "A"}]
+        },
+        {
+          "id": 2,
+          "type": "gauge",
+          "title": "JVM Heap Used",
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "gridPos": {"h": 5, "w": 6, "x": 6, "y": 0},
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "thresholds"},
+              "mappings": [],
+              "max": 100,
+              "min": 0,
+              "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "yellow", "value": 65}, {"color": "red", "value": 85}]},
+              "unit": "percent"
+            },
+            "overrides": []
+          },
+          "options": {"minVizHeight": 75, "minVizWidth": 75, "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "showThresholdLabels": false, "showThresholdMarkers": true},
+          "targets": [{"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "100 * sum(jvm_memory_used_bytes{job=\"spring-api\",area=\"heap\"}) / sum(jvm_memory_max_bytes{job=\"spring-api\",area=\"heap\"})", "instant": true, "legendFormat": "Heap", "refId": "A"}]
+        },
+        {
+          "id": 3,
+          "type": "stat",
+          "title": "JVM Threads",
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "gridPos": {"h": 5, "w": 4, "x": 12, "y": 0},
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "thresholds"},
+              "mappings": [],
+              "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "yellow", "value": 200}, {"color": "red", "value": 500}]},
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "options": {"colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto", "wideLayout": true},
+          "targets": [{"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "jvm_threads_live_threads{job=\"spring-api\"}", "instant": true, "refId": "A"}]
+        },
+        {
+          "id": 4,
+          "type": "stat",
+          "title": "Uptime",
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "gridPos": {"h": 5, "w": 4, "x": 16, "y": 0},
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "thresholds"},
+              "mappings": [],
+              "thresholds": {"mode": "absolute", "steps": [{"color": "red", "value": null}, {"color": "yellow", "value": 60}, {"color": "green", "value": 3600}]},
+              "unit": "dtdurations"
+            },
+            "overrides": []
+          },
+          "options": {"colorMode": "value", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto", "wideLayout": true},
+          "targets": [{"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "process_uptime_seconds{job=\"spring-api\"}", "instant": true, "refId": "A"}]
+        },
+        {
+          "id": 5,
+          "type": "stat",
+          "title": "GC Collections/s",
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "gridPos": {"h": 5, "w": 4, "x": 20, "y": 0},
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "thresholds"},
+              "mappings": [],
+              "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "yellow", "value": 1}, {"color": "red", "value": 5}]},
+              "unit": "ops"
+            },
+            "overrides": []
+          },
+          "options": {"colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto", "wideLayout": true},
+          "targets": [{"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum(rate(jvm_gc_pause_seconds_count{job=\"spring-api\"}[5m]))", "instant": true, "refId": "A"}]
+        },
+        {
+          "id": 6,
+          "type": "timeseries",
+          "title": "CPU Usage",
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "gridPos": {"h": 8, "w": 12, "x": 0, "y": 5},
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic"},
+              "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "drawStyle": "line", "fillOpacity": 15, "gradientMode": "none", "lineWidth": 2, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "never", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}},
+              "mappings": [],
+              "max": 1,
+              "min": 0,
+              "thresholds": {"mode": "absolute", "steps": [{"color": "green"}]},
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "options": {"legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+          "targets": [
+            {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "process_cpu_usage{job=\"spring-api\"}", "legendFormat": "Process CPU", "refId": "A"},
+            {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "system_cpu_usage{job=\"spring-api\"}", "legendFormat": "System CPU", "refId": "B"}
+          ]
+        },
+        {
+          "id": 7,
+          "type": "timeseries",
+          "title": "JVM Memory",
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "gridPos": {"h": 8, "w": 12, "x": 12, "y": 5},
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic"},
+              "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "lineWidth": 1, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "never", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}},
+              "mappings": [],
+              "thresholds": {"mode": "absolute", "steps": [{"color": "green"}]},
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "options": {"legend": {"calcs": ["mean", "last"], "displayMode": "table", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "none"}},
+          "targets": [
+            {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum(jvm_memory_used_bytes{job=\"spring-api\",area=\"heap\"})", "legendFormat": "heap used", "refId": "A"},
+            {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum(jvm_memory_committed_bytes{job=\"spring-api\",area=\"heap\"})", "legendFormat": "heap committed", "refId": "B"},
+            {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum(jvm_memory_max_bytes{job=\"spring-api\",area=\"heap\"})", "legendFormat": "heap max", "refId": "C"},
+            {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum(jvm_memory_used_bytes{job=\"spring-api\",area=\"nonheap\"})", "legendFormat": "nonheap used", "refId": "D"}
+          ]
+        },
+        {
+          "id": 8,
+          "type": "timeseries",
+          "title": "JVM Threads",
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "gridPos": {"h": 8, "w": 12, "x": 0, "y": 13},
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic"},
+              "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "lineWidth": 1, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "never", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}},
+              "mappings": [],
+              "min": 0,
+              "thresholds": {"mode": "absolute", "steps": [{"color": "green"}]},
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "options": {"legend": {"calcs": ["mean", "last"], "displayMode": "table", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "none"}},
+          "targets": [
+            {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "jvm_threads_live_threads{job=\"spring-api\"}", "legendFormat": "live", "refId": "A"},
+            {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "jvm_threads_daemon_threads{job=\"spring-api\"}", "legendFormat": "daemon", "refId": "B"},
+            {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "jvm_threads_peak_threads{job=\"spring-api\"}", "legendFormat": "peak", "refId": "C"}
+          ]
+        },
+        {
+          "id": 9,
+          "type": "timeseries",
+          "title": "GC Activity",
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "gridPos": {"h": 8, "w": 12, "x": 12, "y": 13},
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic"},
+              "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "lineWidth": 1, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "never", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}},
+              "mappings": [],
+              "min": 0,
+              "thresholds": {"mode": "absolute", "steps": [{"color": "green"}]},
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "options": {"legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+          "targets": [
+            {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "rate(jvm_gc_pause_seconds_sum{job=\"spring-api\"}[5m])", "legendFormat": "{{action}} ({{cause}})", "refId": "A"}
+          ]
+        },
+        {
+          "id": 10,
+          "type": "timeseries",
+          "title": "HTTP Request Rate",
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "gridPos": {"h": 8, "w": 12, "x": 0, "y": 21},
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic"},
+              "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "req/s", "axisPlacement": "auto", "drawStyle": "line", "fillOpacity": 15, "gradientMode": "none", "lineWidth": 2, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "never", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}},
+              "mappings": [],
+              "min": 0,
+              "thresholds": {"mode": "absolute", "steps": [{"color": "green"}]},
+              "unit": "reqps"
+            },
+            "overrides": [
+              {"matcher": {"id": "byName", "options": "5xx Errors"}, "properties": [{"id": "color", "value": {"fixedColor": "red", "mode": "fixed"}}]},
+              {"matcher": {"id": "byName", "options": "4xx Errors"}, "properties": [{"id": "color", "value": {"fixedColor": "orange", "mode": "fixed"}}]},
+              {"matcher": {"id": "byName", "options": "Success"}, "properties": [{"id": "color", "value": {"fixedColor": "green", "mode": "fixed"}}]}
+            ]
+          },
+          "options": {"legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+          "targets": [
+            {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum(rate(http_server_requests_seconds_count{job=\"spring-api\",outcome=\"SUCCESS\"}[5m]))", "legendFormat": "Success", "refId": "A"},
+            {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum(rate(http_server_requests_seconds_count{job=\"spring-api\",outcome=\"CLIENT_ERROR\"}[5m]))", "legendFormat": "4xx Errors", "refId": "B"},
+            {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "sum(rate(http_server_requests_seconds_count{job=\"spring-api\",outcome=\"SERVER_ERROR\"}[5m]))", "legendFormat": "5xx Errors", "refId": "C"}
+          ]
+        },
+        {
+          "id": 11,
+          "type": "timeseries",
+          "title": "Log Events by Level",
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "gridPos": {"h": 8, "w": 12, "x": 12, "y": 21},
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic"},
+              "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "events/s", "axisPlacement": "auto", "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "lineWidth": 1, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "never", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}},
+              "mappings": [],
+              "min": 0,
+              "thresholds": {"mode": "absolute", "steps": [{"color": "green"}]},
+              "unit": "short"
+            },
+            "overrides": [
+              {"matcher": {"id": "byName", "options": "error"}, "properties": [{"id": "color", "value": {"fixedColor": "red", "mode": "fixed"}}]},
+              {"matcher": {"id": "byName", "options": "warn"}, "properties": [{"id": "color", "value": {"fixedColor": "orange", "mode": "fixed"}}]},
+              {"matcher": {"id": "byName", "options": "info"}, "properties": [{"id": "color", "value": {"fixedColor": "blue", "mode": "fixed"}}]}
+            ]
+          },
+          "options": {"legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+          "targets": [
+            {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "rate(logback_events_total{job=\"spring-api\",level=\"error\"}[5m])", "legendFormat": "error", "refId": "A"},
+            {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "rate(logback_events_total{job=\"spring-api\",level=\"warn\"}[5m])", "legendFormat": "warn", "refId": "B"},
+            {"datasource": {"type": "prometheus", "uid": "prometheus"}, "expr": "rate(logback_events_total{job=\"spring-api\",level=\"info\"}[5m])", "legendFormat": "info", "refId": "C"}
+          ]
+        }
+      ],
+      "refresh": "30s",
+      "schemaVersion": 39,
+      "tags": ["jvm", "containers"],
+      "templating": {"list": []},
+      "time": {"from": "now-3h", "to": "now"},
+      "timepicker": {},
+      "timezone": "browser",
+      "title": "JVM Container Stats",
+      "uid": "jvm-container-stats",
+      "version": 1,
+      "weekStart": ""
+    }

--- a/infra/k8s/monitoring/grafana-ingress.yaml
+++ b/infra/k8s/monitoring/grafana-ingress.yaml
@@ -1,22 +1,23 @@
 ---
-# Exposes Grafana at https://devsecops.stud.k8s.aet.cit.tum.de/grafana/
-# TLS is already handled by app-ingress in the app namespace for this host.
-# Grafana is configured with GF_SERVER_SERVE_FROM_SUB_PATH=true so it handles
-# the /grafana/ prefix itself — no rewrite-target needed.
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: grafana-ingress
   namespace: monitoring
   annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/proxy-read-timeout: "60"
 spec:
   ingressClassName: nginx
+  tls:
+    - hosts:
+        - grafana.devsecops.stud.k8s.aet.cit.tum.de
+      secretName: grafana-tls-cert
   rules:
-    - host: devsecops.stud.k8s.aet.cit.tum.de
+    - host: grafana.devsecops.stud.k8s.aet.cit.tum.de
       http:
         paths:
-          - path: /grafana
+          - path: /
             pathType: Prefix
             backend:
               service:

--- a/infra/k8s/monitoring/grafana.yaml
+++ b/infra/k8s/monitoring/grafana.yaml
@@ -76,7 +76,15 @@ spec:
                   name: grafana-discord-secret
                   key: webhook-url
           ports:
-            - containerPort: 3000
+            - name: http
+              containerPort: 3000
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            failureThreshold: 12
           volumeMounts:
             - name: datasources
               mountPath: /etc/grafana/provisioning/datasources

--- a/infra/k8s/monitoring/grafana.yaml
+++ b/infra/k8s/monitoring/grafana.yaml
@@ -13,6 +13,13 @@ data:
         url: http://prometheus.monitoring.svc.cluster.local:9090
         isDefault: true
         access: proxy
+  loki.yaml: |
+    apiVersion: 1
+    datasources:
+      - name: Loki
+        type: loki
+        url: http://loki.monitoring.svc.cluster.local:3100
+        access: proxy
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -33,6 +40,7 @@ metadata:
   namespace: monitoring
 spec:
   replicas: 1
+  revisionHistoryLimit: 2
   strategy:
     type: Recreate
   selector:
@@ -47,16 +55,16 @@ spec:
         fsGroup: 472
       containers:
         - name: grafana
-          image: grafana/grafana:11.6.1
+          image: grafana/grafana:11.6.16
           env:
             - name: GF_SECURITY_ADMIN_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: grafana-secret
                   key: admin-password
-            - name: GF_SERVER_ROOT_URL
-              value: https://devsecops.stud.k8s.aet.cit.tum.de/grafana/
-            - name: GF_SERVER_SERVE_FROM_SUB_PATH
+            - name: GF_INSTALL_PLUGINS
+              value: "grafana-metricsdrilldown-app,grafana-lokiexplore-app,grafana-exploretraces-app,grafana-pyroscope-app"
+            - name: GF_PLUGINS_PREINSTALL_DISABLED
               value: "true"
           ports:
             - containerPort: 3000

--- a/infra/k8s/monitoring/grafana.yaml
+++ b/infra/k8s/monitoring/grafana.yaml
@@ -9,6 +9,7 @@ data:
     apiVersion: 1
     datasources:
       - name: Prometheus
+        uid: prometheus
         type: prometheus
         url: http://prometheus.monitoring.svc.cluster.local:9090
         isDefault: true
@@ -17,6 +18,7 @@ data:
     apiVersion: 1
     datasources:
       - name: Loki
+        uid: loki
         type: loki
         url: http://loki.monitoring.svc.cluster.local:3100
         access: proxy
@@ -66,11 +68,24 @@ spec:
               value: "grafana-metricsdrilldown-app,grafana-lokiexplore-app,grafana-exploretraces-app,grafana-pyroscope-app"
             - name: GF_PLUGINS_PREINSTALL_DISABLED
               value: "true"
+            - name: GF_SERVER_ROOT_URL
+              value: "https://grafana.devsecops.stud.k8s.aet.cit.tum.de"
+            - name: DISCORD_WEBHOOK_URL
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-discord-secret
+                  key: webhook-url
           ports:
             - containerPort: 3000
           volumeMounts:
             - name: datasources
               mountPath: /etc/grafana/provisioning/datasources
+            - name: alerting
+              mountPath: /etc/grafana/provisioning/alerting
+            - name: dashboard-provider
+              mountPath: /etc/grafana/provisioning/dashboards
+            - name: dashboards
+              mountPath: /etc/grafana/dashboards
             - name: data
               mountPath: /var/lib/grafana
           resources:
@@ -84,6 +99,15 @@ spec:
         - name: datasources
           configMap:
             name: grafana-datasources
+        - name: alerting
+          configMap:
+            name: grafana-alerting
+        - name: dashboard-provider
+          configMap:
+            name: grafana-dashboard-provider
+        - name: dashboards
+          configMap:
+            name: grafana-dashboard-services
         - name: data
           persistentVolumeClaim:
             claimName: grafana-data

--- a/infra/k8s/monitoring/loki.yaml
+++ b/infra/k8s/monitoring/loki.yaml
@@ -1,0 +1,119 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: loki-config
+  namespace: monitoring
+data:
+  loki.yaml: |
+    auth_enabled: false
+
+    server:
+      http_listen_port: 3100
+
+    common:
+      instance_addr: 127.0.0.1
+      path_prefix: /loki
+      storage:
+        filesystem:
+          chunks_directory: /loki/chunks
+          rules_directory: /loki/rules
+      replication_factor: 1
+      ring:
+        kvstore:
+          store: inmemory
+
+    schema_config:
+      configs:
+        - from: 2024-01-01
+          store: tsdb
+          object_store: filesystem
+          schema: v13
+          index:
+            prefix: index_
+            period: 24h
+
+    limits_config:
+      allow_structured_metadata: true
+
+    analytics:
+      reporting_enabled: false
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: loki-data
+  namespace: monitoring
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: loki
+  namespace: monitoring
+spec:
+  replicas: 1
+  revisionHistoryLimit: 2
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: loki
+  template:
+    metadata:
+      labels:
+        app: loki
+    spec:
+      securityContext:
+        fsGroup: 10001
+      containers:
+        - name: loki
+          image: grafana/loki:3.4.2
+          args:
+            - -config.file=/etc/loki/loki.yaml
+          ports:
+            - containerPort: 3100
+              name: http
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          volumeMounts:
+            - name: config
+              mountPath: /etc/loki
+            - name: data
+              mountPath: /loki
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 384Mi
+      volumes:
+        - name: config
+          configMap:
+            name: loki-config
+        - name: data
+          persistentVolumeClaim:
+            claimName: loki-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: loki
+  namespace: monitoring
+spec:
+  selector:
+    app: loki
+  ports:
+    - name: http
+      port: 3100
+      targetPort: 3100

--- a/infra/k8s/monitoring/prometheus.yaml
+++ b/infra/k8s/monitoring/prometheus.yaml
@@ -49,6 +49,7 @@ metadata:
   namespace: monitoring
 spec:
   replicas: 1
+  revisionHistoryLimit: 2
   strategy:
     type: Recreate
   selector:

--- a/services/spring-api/src/main/resources/application.yaml
+++ b/services/spring-api/src/main/resources/application.yaml
@@ -51,6 +51,10 @@ management:
       probes:
         enabled: true   # creates /actuator/health/liveness and /actuator/health/readiness
       show-details: never  # don't leak datasource URL or other internals in the response
+  metrics:
+    distribution:
+      percentiles-histogram:
+        http.server.requests: true
 
 app:
   jwt:


### PR DESCRIPTION
## Summary

Adds collection of logs to grafana, some dashboards, and alerting.

Closes #120 

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Infrastructure / CI
- [ ] Documentation

## API changes

- [x] This PR does not affect the API
- [ ] This PR changes the API → `api/openapi.yaml` updated and `api/scripts/gen-all.sh` re-run

## Definition of Done

- [ ] CI passes
- [x] Pre-commit hooks pass locally
- [ ] Relevant tests added or updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Grafana Alloy and Loki to centralize application logs.
  * Added new Grafana dashboards and configured Loki as a Grafana data source.
  * Enabled Grafana alerting for key service health/latency/error signals with Discord notifications.
  * Added Spring Actuator percentile metrics for HTTP request performance.
* **Improvements**
  * Refreshed the monitoring stack: updated Grafana, expanded dashboards/alerting provisioning, and adjusted server URL behavior.
  * Updated Grafana ingress to a new TLS-enabled host/path and refreshed the “Try it out!” link.  
* **Operational**
  * Extended rollout handling and introduced a new required Discord webhook secret for alert delivery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->