### PR TITLE
Fix /ai/nutrients contract tests and run service CI on pull requests

### DIFF
--- a/.github/workflows/build-client.yml
+++ b/.github/workflows/build-client.yml
@@ -2,6 +2,11 @@ name: Web Client
 
 on:
   push:
+    branches: [main]
+    paths:
+      - 'web-client/**'
+      - '.github/workflows/build-client.yml'
+  pull_request:
     paths:
       - 'web-client/**'
       - '.github/workflows/build-client.yml'

--- a/.github/workflows/build-help-service.yml
+++ b/.github/workflows/build-help-service.yml
@@ -2,6 +2,14 @@ name: Python Help Service
 
 on:
   push:
+    branches: [main]
+    paths:
+      - 'services/py-help-service/**'
+      - 'api/openapi-internal.yaml'
+      - '.github/workflows/build-help-service.yml'
+  # Runs against the PR's merge commit, so a branch that is green in isolation
+  # but conflicts semantically with main is caught before merge.
+  pull_request:
     paths:
       - 'services/py-help-service/**'
       - 'api/openapi-internal.yaml'

--- a/.github/workflows/build-recipe-service.yml
+++ b/.github/workflows/build-recipe-service.yml
@@ -2,6 +2,14 @@ name: Python Recipe Service
 
 on:
   push:
+    branches: [main]
+    paths:
+      - 'services/py-recipe-service/**'
+      - 'api/openapi-internal.yaml'
+      - '.github/workflows/build-recipe-service.yml'
+  # Runs against the PR's merge commit, so a branch that is green in isolation
+  # but conflicts semantically with main is caught before merge.
+  pull_request:
     paths:
       - 'services/py-recipe-service/**'
       - 'api/openapi-internal.yaml'

--- a/.github/workflows/build-spring-api.yml
+++ b/.github/workflows/build-spring-api.yml
@@ -2,6 +2,14 @@ name: Spring API
 
 on:
   push:
+    branches: [main]
+    paths:
+      - 'services/spring-api/**'
+      - 'web-client/pacts/**'
+      - '.github/workflows/build-spring-api.yml'
+  # Runs against the PR's merge commit, so a branch that is green in isolation
+  # but conflicts semantically with main is caught before merge.
+  pull_request:
     paths:
       - 'services/spring-api/**'
       - 'web-client/pacts/**'

--- a/services/py-help-service/tests/test_contract.py
+++ b/services/py-help-service/tests/test_contract.py
@@ -19,9 +19,9 @@ _ORIGINAL_OPENAPI_SCHEMA = app.openapi_schema
 _CONTRACT_SCHEMA = schemathesis.openapi.from_path(_CONTRACT).raw_schema
 app.openapi_schema = _CONTRACT_SCHEMA
 
-# /ai/recipes belongs to py-recipe-service
+# /ai/recipes and /ai/nutrients belong to py-recipe-service
 schema = schemathesis.openapi.from_asgi("/openapi.json", app).exclude(
-	path="/ai/recipes"
+	path_regex=r"^/ai/(recipes|nutrients)$"
 )
 
 # Happy path only. Auth rejection (missing/invalid HMAC headers) is covered in test_help_service.py.

--- a/services/py-recipe-service/tests/test_contract.py
+++ b/services/py-recipe-service/tests/test_contract.py
@@ -10,7 +10,14 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 import schemathesis
 
-from main import app, get_llm, verify_internal_hmac, RecipeListWrapper, LocalRecipeInput
+from main import (
+	app,
+	get_llm,
+	verify_internal_hmac,
+	RecipeListWrapper,
+	LocalRecipeInput,
+	LocalRecipeNutrients,
+)
 
 _CONTRACT = (
 	pathlib.Path(__file__).resolve().parents[3] / "api" / "openapi-internal.yaml"
@@ -32,21 +39,29 @@ def _stub_provider_dependencies():
 	app.openapi_schema = _CONTRACT_SCHEMA
 	app.dependency_overrides[verify_internal_hmac] = lambda: None
 
-	conforming = RecipeListWrapper(
-		recipes=[
-			LocalRecipeInput(
-				title="Test Recipe",
-				ingredients=[{"quantity": 1.0, "unit": "cup", "name": "Flour"}],
-				instructions=["Mix.", "Bake."],
-				portions=2.0,
-				nutrients={"calories": 200, "protein": 5, "fat": 3, "carbs": 35},
-			)
-		]
-	)
-	structured_runnable = AsyncMock()
-	structured_runnable.ainvoke.return_value = conforming
+	nutrients = LocalRecipeNutrients(calories=200, protein=5, fat=3, carbs=35)
+	conforming = {
+		RecipeListWrapper: RecipeListWrapper(
+			recipes=[
+				LocalRecipeInput(
+					title="Test Recipe",
+					ingredients=[{"quantity": 1.0, "unit": "cup", "name": "Flour"}],
+					instructions=["Mix.", "Bake."],
+					portions=2.0,
+					nutrients=nutrients,
+				)
+			]
+		),
+		LocalRecipeNutrients: nutrients,
+	}
+
+	def _structured_output(schema_class):
+		runnable = AsyncMock()
+		runnable.ainvoke.return_value = conforming[schema_class]
+		return runnable
+
 	llm = MagicMock()
-	llm.with_structured_output.return_value = structured_runnable
+	llm.with_structured_output.side_effect = _structured_output
 	app.dependency_overrides[get_llm] = lambda: llm
 
 	yield


### PR DESCRIPTION
## Summary

Fixes the two contract tests that broke `main` on `216f114`, and runs the service CI workflows on pull requests.

- `py-recipe-service`: the LLM stub always returned a `RecipeListWrapper`, so `/ai/nutrients` answered with the recipes payload instead of `RecipeNutrients`. It now dispatches on the requested schema class.
- `py-help-service`: `/ai/nutrients` belongs to the recipe service and is now excluded, alongside `/ai/recipes`.
- Workflows triggered on `push` only, which never tests a PR against `main` — that is why #131 merged green. Now `pull_request` (tests the merge commit) with `push` limited to `main`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Infrastructure / CI
- [ ] Documentation

## API changes

- [x] This PR does not affect the API
- [ ] This PR changes the API → `api/openapi.yaml` updated and `api/scripts/gen-all.sh` re-run

## Definition of Done

- [x] CI passes
- [x] Pre-commit hooks pass locally
- [x] Relevant tests added or updated
