### PR TITLE
Estimate recipe nutrients with AI from the recipe edit page

### DIFF
--- a/services/py-recipe-service/main.py
+++ b/services/py-recipe-service/main.py
@@ -229,6 +229,7 @@ async def generate_recipes(
 			f"Write all recipe content (title, ingredients, units and instructions) in {language}. "
 			"Strictly use standard, lowercase abbreviated unit names (e.g., use 'tbsp' instead of 'tablespoon', "
 			"'tsp' instead of 'teaspoon', 'g' instead of 'grams', and 'ml' instead of 'milliliters').\n"
+			"Output the nutrients for the whole recipe in total, not per portion.\n"
 			f"Keep the JSON keys in English as specified."
 		)
 
@@ -280,7 +281,8 @@ async def generate_nutrients(
 
 		system_prompt = (
 			"You are an expert nutritional scientist. Calculate the macronutrients and total calories "
-			"for the provided recipe. Evaluate ingredient quantities, units, and base portion sizes carefully. "
+			"for the provided recipe. Output the nutrients for the whole recipe in total, not per portion. "
+			"Evaluate ingredient quantities, units, and base portion sizes carefully. "
 			"Ensure the output strictly mirrors the exact target JSON object fields."
 		)
 

--- a/services/spring-api/src/test/kotlin/org/openapitools/pact/SpringApiProviderPactTest.kt
+++ b/services/spring-api/src/test/kotlin/org/openapitools/pact/SpringApiProviderPactTest.kt
@@ -191,6 +191,9 @@ class SpringApiProviderPactTest {
 			)
 		whenever(recipeServiceApi.aiRecipesPost(any(), any(), any())).thenReturn(recipesCall)
 
+		val nutrientsCall = mockCall(RecipeNutrients(calories = 200, protein = 5, fat = 3, carbs = 35))
+		whenever(recipeServiceApi.aiNutrientsPost(any(), any(), any())).thenReturn(nutrientsCall)
+
 		val helpCall = mockCall(InternalHelpResponse(response = "Grease the pan well."))
 		whenever(helpServiceApi.aiHelpPost(any(), any(), any())).thenReturn(helpCall)
 	}

--- a/web-client/pacts/web-client-spring-api.json
+++ b/web-client/pacts/web-client-spring-api.json
@@ -740,275 +740,6 @@
       }
     },
     {
-      "description": "a request to delete a recipe by id",
-      "providerStates": [
-        {
-          "name": "a user testuser has a recipe"
-        }
-      ],
-      "request": {
-        "headers": {
-          "authorization": "Bearer header.payload.signature"
-        },
-        "matchingRules": {
-          "header": {
-            "authorization": {
-              "combine": "AND",
-              "matchers": [
-                {
-                  "match": "regex",
-                  "regex": "Bearer .+"
-                }
-              ]
-            }
-          }
-        },
-        "method": "DELETE",
-        "path": "/api/v1/recipes/1"
-      },
-      "response": {
-        "status": 204
-      }
-    },
-    {
-      "description": "a request to generate recipes",
-      "providerStates": [
-        {
-          "name": "a user testuser exists"
-        }
-      ],
-      "request": {
-        "body": {
-          "language": "EN",
-          "prompt": "something quick with flour"
-        },
-        "headers": {
-          "Content-Type": "application/json",
-          "authorization": "Bearer header.payload.signature"
-        },
-        "matchingRules": {
-          "header": {
-            "authorization": {
-              "combine": "AND",
-              "matchers": [
-                {
-                  "match": "regex",
-                  "regex": "Bearer .+"
-                }
-              ]
-            }
-          }
-        },
-        "method": "POST",
-        "path": "/api/v1/ai/recipes"
-      },
-      "response": {
-        "body": [
-          {
-            "ingredients": [
-              {
-                "name": "Flour",
-                "quantity": 1,
-                "unit": "cup"
-              }
-            ],
-            "instructions": [
-              "Mix the batter."
-            ],
-            "nutrients": {
-              "calories": 200,
-              "carbs": 35,
-              "fat": 3,
-              "protein": 5
-            },
-            "portions": 2,
-            "title": "Pancakes"
-          }
-        ],
-        "headers": {
-          "Content-Type": "application/json",
-          "content-type": "application/json"
-        },
-        "matchingRules": {
-          "body": {
-            "$": {
-              "combine": "AND",
-              "matchers": [
-                {
-                  "match": "type",
-                  "min": 1
-                }
-              ]
-            },
-            "$[*].ingredients": {
-              "combine": "AND",
-              "matchers": [
-                {
-                  "match": "type",
-                  "min": 1
-                }
-              ]
-            },
-            "$[*].ingredients[*].name": {
-              "combine": "AND",
-              "matchers": [
-                {
-                  "match": "type"
-                }
-              ]
-            },
-            "$[*].ingredients[*].quantity": {
-              "combine": "AND",
-              "matchers": [
-                {
-                  "match": "type"
-                }
-              ]
-            },
-            "$[*].ingredients[*].unit": {
-              "combine": "AND",
-              "matchers": [
-                {
-                  "match": "type"
-                }
-              ]
-            },
-            "$[*].instructions": {
-              "combine": "AND",
-              "matchers": [
-                {
-                  "match": "type",
-                  "min": 1
-                }
-              ]
-            },
-            "$[*].nutrients": {
-              "combine": "AND",
-              "matchers": [
-                {
-                  "match": "type"
-                }
-              ]
-            },
-            "$[*].portions": {
-              "combine": "AND",
-              "matchers": [
-                {
-                  "match": "type"
-                }
-              ]
-            },
-            "$[*].title": {
-              "combine": "AND",
-              "matchers": [
-                {
-                  "match": "type"
-                }
-              ]
-            }
-          },
-          "header": {
-            "content-type": {
-              "combine": "AND",
-              "matchers": [
-                {
-                  "match": "regex",
-                  "regex": "application/json.*"
-                }
-              ]
-            }
-          }
-        },
-        "status": 200
-      }
-    },
-    {
-      "description": "a request for cooking help",
-      "providerStates": [
-        {
-          "name": "a user testuser exists"
-        }
-      ],
-      "request": {
-        "body": {
-          "prompt": "How do I stop it sticking?",
-          "recipe": {
-            "ingredients": [
-              {
-                "name": "Flour",
-                "quantity": 1,
-                "unit": "cup"
-              }
-            ],
-            "instructions": [
-              "Mix the batter.",
-              "Cook on a griddle."
-            ],
-            "nutrients": {
-              "calories": 200,
-              "carbs": 35,
-              "fat": 3,
-              "protein": 5
-            },
-            "portions": 2,
-            "title": "Pancakes"
-          }
-        },
-        "headers": {
-          "Content-Type": "application/json",
-          "authorization": "Bearer header.payload.signature"
-        },
-        "matchingRules": {
-          "header": {
-            "authorization": {
-              "combine": "AND",
-              "matchers": [
-                {
-                  "match": "regex",
-                  "regex": "Bearer .+"
-                }
-              ]
-            }
-          }
-        },
-        "method": "POST",
-        "path": "/api/v1/ai/help"
-      },
-      "response": {
-        "body": {
-          "response": "Grease the pan well."
-        },
-        "headers": {
-          "Content-Type": "application/json",
-          "content-type": "application/json"
-        },
-        "matchingRules": {
-          "body": {
-            "$": {
-              "combine": "AND",
-              "matchers": [
-                {
-                  "match": "type"
-                }
-              ]
-            }
-          },
-          "header": {
-            "content-type": {
-              "combine": "AND",
-              "matchers": [
-                {
-                  "match": "regex",
-                  "regex": "application/json.*"
-                }
-              ]
-            }
-          }
-        },
-        "status": 200
-      }
-    },
-    {
       "description": "a request to update a recipe by id",
       "providerStates": [
         {
@@ -1439,6 +1170,88 @@
       "response": {
         "body": {
           "response": "Grease the pan well."
+        },
+        "headers": {
+          "Content-Type": "application/json",
+          "content-type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          },
+          "header": {
+            "content-type": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "application/json.*"
+                }
+              ]
+            }
+          }
+        },
+        "status": 200
+      }
+    },
+    {
+      "description": "a request to estimate a recipe's nutrients",
+      "providerStates": [
+        {
+          "name": "a user testuser exists"
+        }
+      ],
+      "request": {
+        "body": {
+          "recipe": {
+            "ingredients": [
+              {
+                "name": "Flour",
+                "quantity": 1,
+                "unit": "cup"
+              }
+            ],
+            "instructions": [
+              "Mix the batter.",
+              "Cook on a griddle."
+            ],
+            "portions": 2,
+            "title": "Pancakes"
+          }
+        },
+        "headers": {
+          "Content-Type": "application/json",
+          "authorization": "Bearer header.payload.signature"
+        },
+        "matchingRules": {
+          "header": {
+            "authorization": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "Bearer .+"
+                }
+              ]
+            }
+          }
+        },
+        "method": "POST",
+        "path": "/api/v1/ai/nutrients"
+      },
+      "response": {
+        "body": {
+          "calories": 200,
+          "carbs": 35,
+          "fat": 3,
+          "protein": 5
         },
         "headers": {
           "Content-Type": "application/json",

--- a/web-client/src/locales/de.ts
+++ b/web-client/src/locales/de.ts
@@ -147,6 +147,8 @@ export const DE = {
 			addStep: 'Schritt hinzufügen',
 			removeStep: 'Schritt entfernen',
 			nutrients: 'Nährwerte',
+			estimateNutrients: 'Mit KI schätzen',
+			estimatingNutrients: 'Wird geschätzt…',
 			caloriesLabel: 'Kalorien',
 			proteinLabel: 'Eiweiß',
 			fatLabel: 'Fett',

--- a/web-client/src/locales/en.ts
+++ b/web-client/src/locales/en.ts
@@ -147,6 +147,8 @@ export const EN = {
 			addStep: 'Add step',
 			removeStep: 'Remove step',
 			nutrients: 'Nutrients',
+			estimateNutrients: 'Estimate using AI',
+			estimatingNutrients: 'Estimating…',
 			caloriesLabel: 'Calories',
 			proteinLabel: 'Protein',
 			fatLabel: 'Fat',

--- a/web-client/src/locales/hu.ts
+++ b/web-client/src/locales/hu.ts
@@ -147,6 +147,8 @@ export const HU = {
 			addStep: 'Lépés hozzáadása',
 			removeStep: 'Lépés eltávolítása',
 			nutrients: 'Tápértékek',
+			estimateNutrients: 'Becslés AI-val',
+			estimatingNutrients: 'Becslés folyamatban…',
 			caloriesLabel: 'Kalória',
 			proteinLabel: 'Fehérje',
 			fatLabel: 'Zsír',

--- a/web-client/src/pages/RecipeEditPage.tsx
+++ b/web-client/src/pages/RecipeEditPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { ChevronLeftIcon, PlusIcon, TrashIcon } from '@heroicons/react/24/outline'
+import { ChevronLeftIcon, PlusIcon, SparklesIcon, TrashIcon } from '@heroicons/react/24/outline'
 import { createPortal } from 'react-dom'
 import { Link, Navigate, useBlocker, useLocation, useNavigate, useParams } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
@@ -13,6 +13,7 @@ import { SessionExpiredError, useApi } from '../useApi'
 type Recipe = components['schemas']['RecipeInput'] & { id?: number }
 type RecipeInput = components['schemas']['RecipeInput']
 type RecipeCreated = components['schemas']['RecipeCreated']
+type RecipeNutrients = components['schemas']['RecipeNutrients']
 
 // Editable mirror of a recipe: every field is a string so the inputs stay controlled
 // while the user types (e.g. a half-entered number), and is parsed back on save.
@@ -35,6 +36,8 @@ const NUTRIENTS = [
 const numToStr = (n: number | null | undefined) => (n != null ? String(n) : '')
 
 const isInvalidCount = (s: string) => !(Number.parseFloat(s) >= 0.5)
+// Nutrients may legitimately be zero (a fat-free recipe), unlike portions and quantities.
+const isInvalidAmount = (s: string) => !(Number.parseFloat(s) >= 0)
 const isBlankIngredient = (ing: IngredientDraft) =>
 	ing.name.trim() === '' && ing.unit.trim() === '' && ing.quantity.trim() === ''
 
@@ -59,8 +62,9 @@ function toDraft(recipe: Recipe): RecipeDraft {
 
 const toInt = (s: string) => Math.round(Number.parseFloat(s))
 
-// Parse a validated draft into a RecipeInput payload: drop fully-blank rows, coerce numbers.
-function buildRecipeInput(draft: RecipeDraft): RecipeInput {
+// Parse a validated draft into the recipe itself: drop fully-blank rows, coerce numbers.
+// Nutrients are excluded — they are what the estimator derives from these fields.
+function buildRecipe(draft: RecipeDraft): Omit<RecipeInput, 'nutrients'> {
 	const ingredients = draft.ingredients
 		.filter((ing) => !isBlankIngredient(ing))
 		.map((ing) => ({
@@ -74,6 +78,12 @@ function buildRecipeInput(draft: RecipeDraft): RecipeInput {
 		ingredients,
 		instructions,
 		portions: Number.parseFloat(draft.portions),
+	}
+}
+
+function buildRecipeInput(draft: RecipeDraft): RecipeInput {
+	return {
+		...buildRecipe(draft),
 		nutrients: {
 			calories: toInt(draft.nutrients.calories),
 			protein: toInt(draft.nutrients.protein),
@@ -198,6 +208,8 @@ function RecipeEditor({
 	const [saving, setSaving] = useState(false)
 	const [saveError, setSaveError] = useState<string | null>(null)
 	const [askPersist, setAskPersist] = useState(false)
+	const [estimating, setEstimating] = useState(false)
+	const [nutrientsError, setNutrientsError] = useState<string | null>(null)
 
 	// warn if edits would get discarded
 	const [initialJson] = useState(() => JSON.stringify(toDraft(recipe)))
@@ -213,14 +225,19 @@ function RecipeEditor({
 
 	const titleInvalid = draft.title.trim() === ''
 	const portionsInvalid = isInvalidCount(draft.portions)
-	const nutrientInvalid = (key: (typeof NUTRIENTS)[number]['key']) => isInvalidCount(draft.nutrients[key])
+	const nutrientInvalid = (key: (typeof NUTRIENTS)[number]['key']) => isInvalidAmount(draft.nutrients[key])
 	const ingredientQtyInvalid = (ing: IngredientDraft) => !isBlankIngredient(ing) && isInvalidCount(ing.quantity)
 
-	const hasErrors =
-    titleInvalid ||
-    portionsInvalid ||
-    NUTRIENTS.some((n) => nutrientInvalid(n.key)) ||
-    draft.ingredients.some(ingredientQtyInvalid)
+	const recipeInvalid = titleInvalid ||
+		portionsInvalid ||
+		draft.ingredients.some(ingredientQtyInvalid)
+
+	const hasErrors = recipeInvalid || NUTRIENTS.some((n) => nutrientInvalid(n.key))
+
+	const estimatable =
+    !recipeInvalid &&
+    draft.ingredients.some((ing) => !isBlankIngredient(ing)) &&
+    draft.instructions.some((step) => step.trim() !== '')
 
 	// synchronized widths so the quantity and unit columns line up across every row
 	const qtyColWidth = columnWidth(draft.ingredients.map((i) => i.quantity), 4)
@@ -231,6 +248,35 @@ function RecipeEditor({
 			...d,
 			ingredients: d.ingredients.map((ing, i) => (i === index ? { ...ing, ...patch } : ing)),
 		}))
+	}
+
+	async function estimateNutrients() {
+		if (!estimatable) return
+		setEstimating(true)
+		setNutrientsError(null)
+		try {
+			const res = await apiFetch('/ai/nutrients', {
+				method: 'POST',
+				headers: { 'content-type': 'application/json' },
+				body: JSON.stringify({ recipe: buildRecipe(draft) }),
+			})
+			if (!res.ok) throw new Error(await errorMessage(res))
+			const estimated = (await res.json()) as RecipeNutrients
+			setDraft((d) => ({
+				...d,
+				nutrients: {
+					calories: numToStr(estimated.calories),
+					protein: numToStr(estimated.protein),
+					fat: numToStr(estimated.fat),
+					carbs: numToStr(estimated.carbs),
+				},
+			}))
+		} catch (e) {
+			if (e instanceof SessionExpiredError) return
+			setNutrientsError(t('common.error', { message: e instanceof Error ? e.message : String(e) }))
+		} finally {
+			setEstimating(false)
+		}
 	}
 
 	// `persist` only applies to a recipe that isn't in the library yet
@@ -427,25 +473,38 @@ function RecipeEditor({
 
 				{/* Nutrients */}
 				<div className={sectionCard}>
-					<h3 className="text-lg font-bold">{t('recipe.nutrients')}</h3>
+					<div className="flex items-center justify-between gap-3">
+						<h3 className="text-lg font-bold">{t('recipe.nutrients')}</h3>
+						<button
+							type="button"
+							onClick={() => void estimateNutrients()}
+							disabled={estimating || !estimatable}
+							className="flex items-center gap-1 text-gray-500 dark:text-neutral-400 cursor-pointer transition-transform duration-100 hover:scale-98 disabled:opacity-50 disabled:cursor-default"
+						>
+							<SparklesIcon className="h-5 w-5" />
+							{estimating ? t('recipe.estimatingNutrients') : t('recipe.estimateNutrients')}
+						</button>
+					</div>
 					<div className="mt-1 flex flex-col gap-2">
 						{NUTRIENTS.map(({ key, labelKey, unit }) => (
 							<label key={key} className="flex items-center gap-2">
 								<input
 									type="number"
-									min={0.5}
+									min={0}
 									value={draft.nutrients[key]}
+									disabled={estimating}
 									onChange={(e) =>
 										setDraft((d) => ({ ...d, nutrients: { ...d.nutrients, [key]: e.target.value } }))
 									}
 									aria-label={t(labelKey)}
-									className={`no-spinner w-20 text-right ${inputBase} ${borderFor(nutrientInvalid(key))}`}
+									className={`no-spinner w-20 text-right ${inputBase} ${borderFor(nutrientInvalid(key))} disabled:opacity-50`}
 								/>
 								<span className="w-10 text-gray-500 dark:text-neutral-400">{unit}</span>
 								<span className="font-medium">{t(labelKey)}</span>
 							</label>
 						))}
 					</div>
+					{nutrientsError && <p className="mt-2 text-red-600 dark:text-red-400">{nutrientsError}</p>}
 				</div>
 
 				{saveError && !askPersist && <p className="text-red-600 dark:text-red-400">{saveError}</p>}

--- a/web-client/tests/pact/spring-api.pact.test.ts
+++ b/web-client/tests/pact/spring-api.pact.test.ts
@@ -5,6 +5,7 @@
  * server for every route the client uses, and generates a pact. The pact
  * (web-client/pacts/) is later replayed against the running Spring provider.
  */
+import { rmSync } from 'node:fs'
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 import { act, renderHook } from '@testing-library/react'
 import { MatchersV3, PactV3 } from '@pact-foundation/pact'
@@ -37,6 +38,14 @@ const recipeInputBody = {
 	nutrients: { calories: 200, protein: 5, fat: 3, carbs: 35 },
 }
 
+// Nutrient estimation deliberately omits `nutrients` — they are what it derives.
+const recipeWithoutNutrientsBody = {
+	title: 'Pancakes',
+	ingredients: [{ quantity: 1, unit: 'cup', name: 'Flour' }],
+	instructions: ['Mix the batter.', 'Cook on a griddle.'],
+	portions: 2,
+}
+
 const recipeResponseShape = {
 	id: integer(1),
 	title: like('Pancakes'),
@@ -64,7 +73,10 @@ const preferencesShape = {
 	aboutMe: eachLike('Home cook on a budget'),
 }
 
+const PACT_FILE = 'pacts/web-client-spring-api.json'
+
 beforeAll(async () => {
+	rmSync(PACT_FILE, { force: true })
 	vi.stubEnv('VITE_API_BASE', `http://127.0.0.1:${MOCK_PORT}`)
 	auth = await import('../../src/auth')
 	api = await import('../../src/useApi')
@@ -223,6 +235,21 @@ describe('web-client → spring-api pact', () => {
 				body: like({ response: 'Grease the pan well.' }),
 			})
 
+		pact
+			.given('a user testuser exists')
+			.uponReceiving("a request to estimate a recipe's nutrients")
+			.withRequest({
+				method: 'POST',
+				path: '/api/v1/ai/nutrients',
+				headers: { ...bearer, ...jsonHeaders },
+				body: { recipe: recipeWithoutNutrientsBody },
+			})
+			.willRespondWith({
+				status: 200,
+				headers: jsonResponse,
+				body: like({ calories: 200, protein: 5, fat: 3, carbs: 35 }),
+			})
+
 		// --- Error responses the client branches on ---
 		// 401: useApi signs the user out. Distinguishable from the happy path by the
 		// absence of a token (Pact can't tell two identical requests apart by state).
@@ -316,6 +343,12 @@ describe('web-client → spring-api pact', () => {
 				body: JSON.stringify({ recipe: recipeInputBody, prompt: 'How do I stop it sticking?' }),
 			})
 			expect((await help.json()).response).toBeTruthy()
+			const nutrients = await call('/ai/nutrients', {
+				method: 'POST',
+				headers: jsonHeaders,
+				body: JSON.stringify({ recipe: recipeWithoutNutrientsBody }),
+			})
+			expect((await nutrients.json()).calories).toBeGreaterThanOrEqual(0)
 
 			// Error responses (useApi only throws on 401/403, so these return normally).
 			expect((await call('/recipes/999')).status).toBe(404)

--- a/web-client/tests/pages/RecipeEditPage.test.tsx
+++ b/web-client/tests/pages/RecipeEditPage.test.tsx
@@ -164,6 +164,83 @@ describe('RecipeEditPage', () => {
 		expect(screen.getByRole('button', {name: 'Save'})).toBeDisabled()
 	})
 
+	it('estimates nutrients from the live draft, sending the recipe without its nutrients', async () => {
+		const user = userEvent.setup()
+		fetchMock.mockResolvedValueOnce(jsonResponse(a)) // initial GET
+		renderLibraryEdit(1)
+
+		// edit an ingredient first: the estimate must reflect the draft, not the fetched recipe
+		const names = await screen.findAllByLabelText('Ingredient')
+		await user.clear(names[0])
+		await user.type(names[0], 'aubergine')
+
+		fetchMock.mockResolvedValueOnce(jsonResponse({calories: 123, protein: 7, fat: 4, carbs: 15}))
+		await user.click(screen.getByRole('button', {name: 'Estimate using AI'}))
+
+		const postCall = fetchMock.mock.calls.find(([url]) => String(url).endsWith('/ai/nutrients'))!
+		const body = JSON.parse(String(postCall[1]!.body))
+		expect(body.recipe).toEqual({
+			title: 'Tomato Pasta',
+			portions: 2,
+			ingredients: [{name: 'aubergine', quantity: 4, unit: 'pcs'}],
+			instructions: ['boil pasta', 'add sauce'],
+		})
+		expect(body.recipe).not.toHaveProperty('nutrients')
+
+		// the fixture's nutrients (500/20/10/60) are overwritten unconditionally
+		expect(await screen.findByDisplayValue('123')).toBeInTheDocument()
+		expect(screen.getByLabelText('Protein')).toHaveValue(7)
+		expect(screen.getByLabelText('Fat')).toHaveValue(4)
+		expect(screen.getByLabelText('Carbs')).toHaveValue(15)
+	})
+
+	it('accepts a zero nutrient estimate and stays saveable', async () => {
+		const user = userEvent.setup()
+		fetchMock.mockResolvedValueOnce(jsonResponse(a))
+		renderLibraryEdit(1)
+		await screen.findByDisplayValue('Tomato Pasta')
+
+		fetchMock.mockResolvedValueOnce(jsonResponse({calories: 0, protein: 0, fat: 0, carbs: 0}))
+		await user.click(screen.getByRole('button', {name: 'Estimate using AI'}))
+
+		const fat = await screen.findByLabelText('Fat')
+		expect(fat).toHaveValue(0)
+		expect(fat.className).not.toContain('border-red-500')
+		expect(screen.getByRole('button', {name: 'Save'})).toBeEnabled()
+	})
+
+	it('shows an error in the nutrients card when the estimate fails, keeping the values', async () => {
+		const user = userEvent.setup()
+		fetchMock.mockResolvedValueOnce(jsonResponse(a))
+		renderLibraryEdit(1)
+		await screen.findByDisplayValue('Tomato Pasta')
+
+		fetchMock.mockResolvedValueOnce(jsonResponse({message: 'GenAI service unavailable'}, {status: 502}))
+		await user.click(screen.getByRole('button', {name: 'Estimate using AI'}))
+
+		expect(await screen.findByText(/GenAI service unavailable/)).toBeInTheDocument()
+		expect(screen.getByLabelText('Calories')).toHaveValue(500)
+		expect(screen.getByRole('button', {name: 'Estimate using AI'})).toBeEnabled()
+	})
+
+	it('disables the estimate button until the recipe itself is complete', async () => {
+		const user = userEvent.setup()
+		fetchMock.mockResolvedValueOnce(jsonResponse(a))
+		renderLibraryEdit(1)
+
+		const title = await screen.findByDisplayValue('Tomato Pasta')
+		expect(screen.getByRole('button', {name: 'Estimate using AI'})).toBeEnabled()
+
+		// a blank title cannot be sent
+		await user.clear(title)
+		expect(screen.getByRole('button', {name: 'Estimate using AI'})).toBeDisabled()
+		await user.type(title, 'Tomato Pasta')
+
+		// the contract requires at least one ingredient (minItems: 1)
+		await user.click(screen.getByRole('button', {name: 'Remove ingredient'}))
+		expect(screen.getByRole('button', {name: 'Estimate using AI'})).toBeDisabled()
+	})
+
 	it('keeps an edited unsaved recipe as a draft without any network call', async () => {
 		const user = userEvent.setup()
 		const unsaved = {...a, id: undefined} as unknown as Recipe

--- a/web-client/tsconfig.app.json
+++ b/web-client/tsconfig.app.json
@@ -4,7 +4,7 @@
     "target": "es2023",
     "lib": ["ES2023", "DOM"],
     "module": "esnext",
-    "types": ["vite/client", "vitest/globals"],
+    "types": ["vite/client", "vitest/globals", "node"],
     "skipLibCheck": true,
 
     /* Bundler mode */


### PR DESCRIPTION
## Summary

Adds an "Estimate using AI" button to the nutrients card on the recipe edit page. It posts the live draft (without its nutrients) to the existing `/ai/nutrients` endpoint and overwrites the four values.

Nutrients may now be zero — `0` is contract-legal (`minimum: 0`), unlike portions and quantities, so a legitimate estimate of `0` no longer flags the field and blocks Save.

Also prompts the recipe service for whole-recipe nutrients rather than per portion, and regenerates the pact from scratch on each run (Pact merges into the existing file, which had accumulated three duplicate interactions).

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Infrastructure / CI
- [ ] Documentation

## API changes

- [x] This PR does not affect the API
- [ ] This PR changes the API → `api/openapi.yaml` updated and `api/scripts/gen-all.sh` re-run

## Definition of Done

- [x] CI passes
- [x] Pre-commit hooks pass locally
- [x] Relevant tests added or updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an AI-powered option to estimate recipe nutrients from the recipe editor.
  * Nutrient estimates now update calories, protein, fat, and carbohydrates automatically.
  * Added localized labels and progress messages in English, German, and Hungarian.
* **Improvements**
  * Nutrient values of zero are now accepted.
  * Estimation is unavailable until the recipe has a valid title and ingredients.
* **Bug Fixes**
  * Clear error messages are shown when nutrient estimation fails while preserving existing values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->