### PR TITLE
Show proper logs on azure deployment crash

### DIFF
--- a/.github/workflows/deploy-ansible.yml
+++ b/.github/workflows/deploy-ansible.yml
@@ -1,4 +1,4 @@
-name: Deploy to Production
+name: Deploy to Azure
 
 on:
   push:

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -11,7 +11,7 @@
         name: [git, python3-docker, python3-pip]
         state: present
         update_cache: yes
-    
+
     - name: Install Docker via official script
       shell: curl -fsSL https://get.docker.com -o get-docker.sh && sh get-docker.sh
       args:
@@ -82,12 +82,29 @@
           command: docker compose up -d --build
           args:
             chdir: /var/www/app/infra
+          environment:
+            DOCKER_BUILDKIT: "1"
           register: compose_output
 
       rescue:
-        - name: Show Docker logs if deployment fails
+        - name: Show compose stdout on failure
           debug:
             var: compose_output.stdout_lines
+
+        - name: Show compose stderr on failure
+          debug:
+            var: compose_output.stderr_lines
+
+        - name: Show per-service container logs on failure
+          command: docker compose logs --no-color
+          args:
+            chdir: /var/www/app/infra
+          ignore_errors: yes
+          register: compose_logs
+
+        - name: Print container logs
+          debug:
+            var: compose_logs.stdout_lines
 
         - name: Fail the playbook so GitHub knows it failed
           fail:


### PR DESCRIPTION
## Summary

Azure deployment crashes, this pr fixes it

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Infrastructure / CI
- [ ] Documentation

## API changes

- [x] This PR does not affect the API
- [ ] This PR changes the API → `api/openapi.yaml` updated and `api/scripts/gen-all.sh` re-run

## Definition of Done

- [ ] CI passes
- [x] Pre-commit hooks pass locally
- [ ] Relevant tests added or updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker deployment diagnostics by displaying both command output and service container logs when deployment fails.
  * Enabled Docker BuildKit for faster and more reliable Compose builds.
  * Deployment failures now provide more actionable troubleshooting details before stopping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->