### PR TITLE
fix: run az in pinned azure/cli container (Python 3.14 deadlock)

### DIFF
--- a/.github/workflows/deploy-ansible.yml
+++ b/.github/workflows/deploy-ansible.yml
@@ -36,16 +36,20 @@ jobs:
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
       - name: Resolve VM public IP
-        run: |
-          IP=$(az vm show -d \
-            --resource-group "$RESOURCE_GROUP" \
-            --name "$VM_NAME" \
-            --query publicIps -o tsv)
-          if [ -z "$IP" ]; then
-            echo "::error::VM has no public IP. Run 'Start environment' first."
-            exit 1
-          fi
-          echo "VM_IP=$IP" >> "$GITHUB_ENV"
+        id: ip
+        uses: azure/cli@v2
+        with:
+          azcliversion: "2.64.0"
+          inlineScript: |
+            IP=$(az vm show -d \
+              --resource-group "$RESOURCE_GROUP" \
+              --name "$VM_NAME" \
+              --query publicIps -o tsv)
+            if [ -z "$IP" ]; then
+              echo "::error::VM has no public IP. Run 'Start environment' first."
+              exit 1
+            fi
+            echo "ip=$IP" >> "$GITHUB_OUTPUT"
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -64,9 +68,13 @@ jobs:
           known_hosts: 'placeholder' # Will be overwritten by ssh-keyscan next
 
       - name: Scan VM Host Key
+        env:
+          VM_IP: ${{ steps.ip.outputs.ip }}
         run: ssh-keyscan -H "$VM_IP" >> ~/.ssh/known_hosts
 
       - name: Write inventory with the resolved IP
+        env:
+          VM_IP: ${{ steps.ip.outputs.ip }}
         run: |
           cat > infra/inventory.ini <<EOF
           [web]

--- a/.github/workflows/vm-start.yml
+++ b/.github/workflows/vm-start.yml
@@ -36,52 +36,40 @@ jobs:
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Create public IP (if missing)
-        run: |
-          az network public-ip create \
-            --resource-group "$RESOURCE_GROUP" \
-            --name "$PIP_NAME" \
-            --location "$LOCATION" \
-            --sku Standard \
-            --allocation-method Static \
-            --only-show-errors
-
-      - name: Attach public IP to the VM's NIC
-        run: |
-          az network nic ip-config update \
-            --resource-group "$RESOURCE_GROUP" \
-            --nic-name "$NIC_NAME" \
-            --name "$IP_CONFIG" \
-            --public-ip-address "$PIP_NAME" \
-            --only-show-errors
-
-      - name: Start the VM
-        run: az vm start --resource-group "$RESOURCE_GROUP" --name "$VM_NAME"
-
-      - name: Arm auto-shutdown timer (now + minutes, UTC)
+      - name: Compute auto-shutdown time (UTC)
+        id: t
         env:
           MINUTES: ${{ github.event.inputs.minutes }}
-        run: |
-          SHUTDOWN=$(date -u -d "+${MINUTES} minutes" +%H%M)
-          az vm auto-shutdown \
-            --resource-group "$RESOURCE_GROUP" \
-            --name "$VM_NAME" \
-            --time "$SHUTDOWN"
-          echo "SHUTDOWN_UTC=$SHUTDOWN" >> "$GITHUB_ENV"
+        run: echo "shutdown=$(date -u -d "+${MINUTES} minutes" +%H%M)" >> "$GITHUB_OUTPUT"
 
-      - name: Publish the URL
+      - name: Start the environment
+        uses: azure/cli@v2
         env:
+          SHUTDOWN: ${{ steps.t.outputs.shutdown }}
           MINUTES: ${{ github.event.inputs.minutes }}
-        run: |
-          IP=$(az network public-ip show \
-            --resource-group "$RESOURCE_GROUP" \
-            --name "$PIP_NAME" \
-            --query ipAddress -o tsv)
-          {
-            echo "### 🚀 Environment starting"
-            echo ""
-            echo "**URL:** http://$IP  (allow ~1–2 min for containers to come up)"
-            echo ""
-            echo "Auto-shutdown armed for **${SHUTDOWN_UTC} UTC** (in ${MINUTES} min)."
-            echo "Run **Stop environment** to end early and release the IP."
-          } >> "$GITHUB_STEP_SUMMARY"
+        with:
+          azcliversion: "2.64.0"
+          inlineScript: |
+            set -e
+            az network public-ip create \
+              --resource-group "$RESOURCE_GROUP" --name "$PIP_NAME" \
+              --location "$LOCATION" --sku Standard --allocation-method Static \
+              --only-show-errors
+            az network nic ip-config update \
+              --resource-group "$RESOURCE_GROUP" --nic-name "$NIC_NAME" \
+              --name "$IP_CONFIG" --public-ip-address "$PIP_NAME" --only-show-errors
+            az vm start --resource-group "$RESOURCE_GROUP" --name "$VM_NAME"
+            az vm auto-shutdown \
+              --resource-group "$RESOURCE_GROUP" --name "$VM_NAME" --time "$SHUTDOWN"
+            IP=$(az network public-ip show \
+              --resource-group "$RESOURCE_GROUP" --name "$PIP_NAME" \
+              --query ipAddress -o tsv)
+            echo "Environment URL: http://$IP (auto-shutdown ${SHUTDOWN} UTC, in ${MINUTES} min)"
+            {
+              echo "### 🚀 Environment starting"
+              echo ""
+              echo "**URL:** http://$IP  (allow ~1–2 min for containers to come up)"
+              echo ""
+              echo "Auto-shutdown armed for **${SHUTDOWN} UTC** (in ${MINUTES} min)."
+              echo "Run **Stop environment** to end early and release the IP."
+            } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/vm-stop.yml
+++ b/.github/workflows/vm-stop.yml
@@ -29,26 +29,19 @@ jobs:
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Deallocate the VM
-        run: az vm deallocate --resource-group "$RESOURCE_GROUP" --name "$VM_NAME"
-
-      - name: Detach and delete the public IP
-        run: |
-          az network nic ip-config update \
-            --resource-group "$RESOURCE_GROUP" \
-            --nic-name "$NIC_NAME" \
-            --name "$IP_CONFIG" \
-            --remove publicIpAddress \
-            --only-show-errors || true
-          az network public-ip delete \
-            --resource-group "$RESOURCE_GROUP" \
-            --name "$PIP_NAME" \
-            --only-show-errors || true
-
-      - name: Summary
-        run: |
-          {
-            echo "### 🛑 Environment stopped"
-            echo ""
+      - name: Stop the environment
+        uses: azure/cli@v2
+        with:
+          azcliversion: "2.64.0"
+          inlineScript: |
+            az vm deallocate --resource-group "$RESOURCE_GROUP" --name "$VM_NAME"
+            az network nic ip-config update \
+              --resource-group "$RESOURCE_GROUP" --nic-name "$NIC_NAME" \
+              --name "$IP_CONFIG" --remove publicIpAddress --only-show-errors || true
+            az network public-ip delete \
+              --resource-group "$RESOURCE_GROUP" --name "$PIP_NAME" --only-show-errors || true
+            {
+              echo "### 🛑 Environment stopped"
+              echo ""
             echo "VM deallocated and public IP released."
-          } >> "$GITHUB_STEP_SUMMARY"
+            } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

**Start environment** failed at "Attach public IP" because the runner's bundled Azure CLI runs on Python 3.14, which deadlocks on concurrent command-module loading ([Azure/azure-cli#32980](https://github.com/Azure/azure-cli/issues/32980)) — a flaky race, not our logic. All `az` commands now run inside the pinned `azure/cli@v2` container (known-good CLI/Python), reusing the OIDC login. Date math stays on the host (the container image is Alpine, no GNU `date`).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Infrastructure / CI
- [ ] Documentation

## API changes

- [x] This PR does not affect the API
- [ ] This PR changes the API → `api/openapi.yaml` updated and `api/scripts/gen-all.sh` re-run

## Definition of Done

- [ ] CI passes
- [x] Pre-commit hooks pass locally
- [ ] Relevant tests added or updated
