### PR TITLE
fix: federated OIDC login inside azure/cli container

### DIFF
--- a/.github/workflows/deploy-ansible.yml
+++ b/.github/workflows/deploy-ansible.yml
@@ -28,19 +28,32 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Azure login (OIDC)
-        uses: azure/login@v2
-        with:
-          client-id: ${{ vars.AZURE_CLIENT_ID }}
-          tenant-id: ${{ vars.AZURE_TENANT_ID }}
-          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+      - name: Get OIDC token
+        id: prep
+        run: |
+          TOKEN=$(curl -sS \
+            -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=api://AzureADTokenExchange" \
+            | jq -r '.value')
+          echo "::add-mask::$TOKEN"
+          echo "token=$TOKEN" >> "$GITHUB_OUTPUT"
 
       - name: Resolve VM public IP
         id: ip
         uses: azure/cli@v2
+        env:
+          FED_TOKEN: ${{ steps.prep.outputs.token }}
+          AZURE_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
+          AZURE_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
+          AZURE_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
         with:
           azcliversion: "2.64.0"
           inlineScript: |
+            set -e
+            az login --service-principal \
+              --username "$AZURE_CLIENT_ID" --tenant "$AZURE_TENANT_ID" \
+              --federated-token "$FED_TOKEN" --output none
+            az account set --subscription "$AZURE_SUBSCRIPTION_ID"
             IP=$(az vm show -d \
               --resource-group "$RESOURCE_GROUP" \
               --name "$VM_NAME" \

--- a/.github/workflows/vm-start.yml
+++ b/.github/workflows/vm-start.yml
@@ -29,28 +29,36 @@ jobs:
   start:
     runs-on: ubuntu-latest
     steps:
-      - name: Azure login (OIDC)
-        uses: azure/login@v2
-        with:
-          client-id: ${{ vars.AZURE_CLIENT_ID }}
-          tenant-id: ${{ vars.AZURE_TENANT_ID }}
-          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
-
-      - name: Compute auto-shutdown time (UTC)
-        id: t
+      - name: Get OIDC token & compute shutdown time
+        id: prep
         env:
           MINUTES: ${{ github.event.inputs.minutes }}
-        run: echo "shutdown=$(date -u -d "+${MINUTES} minutes" +%H%M)" >> "$GITHUB_OUTPUT"
+        run: |
+          TOKEN=$(curl -sS \
+            -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=api://AzureADTokenExchange" \
+            | jq -r '.value')
+          echo "::add-mask::$TOKEN"
+          echo "token=$TOKEN" >> "$GITHUB_OUTPUT"
+          echo "shutdown=$(date -u -d "+${MINUTES} minutes" +%H%M)" >> "$GITHUB_OUTPUT"
 
       - name: Start the environment
         uses: azure/cli@v2
         env:
-          SHUTDOWN: ${{ steps.t.outputs.shutdown }}
+          FED_TOKEN: ${{ steps.prep.outputs.token }}
+          SHUTDOWN: ${{ steps.prep.outputs.shutdown }}
           MINUTES: ${{ github.event.inputs.minutes }}
+          AZURE_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
+          AZURE_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
+          AZURE_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
         with:
           azcliversion: "2.64.0"
           inlineScript: |
             set -e
+            az login --service-principal \
+              --username "$AZURE_CLIENT_ID" --tenant "$AZURE_TENANT_ID" \
+              --federated-token "$FED_TOKEN" --output none
+            az account set --subscription "$AZURE_SUBSCRIPTION_ID"
             az network public-ip create \
               --resource-group "$RESOURCE_GROUP" --name "$PIP_NAME" \
               --location "$LOCATION" --sku Standard --allocation-method Static \

--- a/.github/workflows/vm-stop.yml
+++ b/.github/workflows/vm-stop.yml
@@ -22,18 +22,31 @@ jobs:
   stop:
     runs-on: ubuntu-latest
     steps:
-      - name: Azure login (OIDC)
-        uses: azure/login@v2
-        with:
-          client-id: ${{ vars.AZURE_CLIENT_ID }}
-          tenant-id: ${{ vars.AZURE_TENANT_ID }}
-          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+      - name: Get OIDC token
+        id: prep
+        run: |
+          TOKEN=$(curl -sS \
+            -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=api://AzureADTokenExchange" \
+            | jq -r '.value')
+          echo "::add-mask::$TOKEN"
+          echo "token=$TOKEN" >> "$GITHUB_OUTPUT"
 
       - name: Stop the environment
         uses: azure/cli@v2
+        env:
+          FED_TOKEN: ${{ steps.prep.outputs.token }}
+          AZURE_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
+          AZURE_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
+          AZURE_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
         with:
           azcliversion: "2.64.0"
           inlineScript: |
+            set -e
+            az login --service-principal \
+              --username "$AZURE_CLIENT_ID" --tenant "$AZURE_TENANT_ID" \
+              --federated-token "$FED_TOKEN" --output none
+            az account set --subscription "$AZURE_SUBSCRIPTION_ID"
             az vm deallocate --resource-group "$RESOURCE_GROUP" --name "$VM_NAME"
             az network nic ip-config update \
               --resource-group "$RESOURCE_GROUP" --nic-name "$NIC_NAME" \


### PR DESCRIPTION
## Summary

Follow-up to #144. The container CLI still failed at login: `azure/login` ran on the host with a newer MSAL and wrote a token cache the pinned container CLI (2.64.0 / Python 3.9) couldn't deserialize (`NormalizedResponse` AttributeError). Drop `azure/login`; instead fetch the GitHub OIDC token on the host and run `az login --service-principal --federated-token` **inside** the container, so one CLI/MSAL version both authenticates and runs the commands. Applied to all three workflows.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Infrastructure / CI
- [ ] Documentation

## API changes

- [x] This PR does not affect the API
- [ ] This PR changes the API → `api/openapi.yaml` updated and `api/scripts/gen-all.sh` re-run

## Definition of Done

- [ ] CI passes
- [x] Pre-commit hooks pass locally
- [ ] Relevant tests added or updated
